### PR TITLE
Remote audio mute and un-mute fixes

### DIFF
--- a/ninchatsdk/src/main/java/com/ninchat/sdk/views/NinchatWebRTCView.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/views/NinchatWebRTCView.java
@@ -517,9 +517,19 @@ public final class NinchatWebRTCView implements PeerConnection.Observer, SdpObse
     }
 
     private void toggleAudio(final boolean mute) {
-        final AudioManager audioManager = (AudioManager) videoContainer.getContext().getSystemService(Context.AUDIO_SERVICE);
-        audioManager.adjustStreamVolume(AudioManager.STREAM_MUSIC, mute ? AudioManager.ADJUST_MUTE : AudioManager.ADJUST_UNMUTE, 0);
-        audioManager.adjustStreamVolume(AudioManager.STREAM_SYSTEM, mute ? AudioManager.ADJUST_MUTE : AudioManager.ADJUST_UNMUTE, 0);
+        // sanity check
+        if (peerConnection == null) {
+            return;
+        }
+        // https://w3c.github.io/webrtc-pc/#rtcrtpreceiver-interface
+        for (final RtpTransceiver transceiver : peerConnection.getTransceivers()) {
+            if (transceiver.getMediaType() == MediaStreamTrack.MediaType.MEDIA_TYPE_AUDIO) {
+                final MediaStreamTrack mediaStreamTrack = transceiver.getReceiver().track();
+                if (mediaStreamTrack != null) {
+                    mediaStreamTrack.setEnabled(!mute);
+                }
+            }
+        }
     }
 
     private boolean isMicrophoneMuted = false;


### PR DESCRIPTION
Fix for remote audio mute using RtpTransceiver. Previously, even if the speaker is disabled, other parties audio can still be heard.

- https://github.com/somia/mobile/issues/92