### PR TITLE
Sync media icon with right AV states

### DIFF
--- a/ninchatsdk/src/main/java/com/ninchat/sdk/views/NinchatWebRTCView.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/views/NinchatWebRTCView.java
@@ -1,7 +1,5 @@
 package com.ninchat.sdk.views;
 
-import android.content.Context;
-import android.media.AudioManager;
 import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
@@ -501,7 +499,7 @@ public final class NinchatWebRTCView implements PeerConnection.Observer, SdpObse
         PeerConnectionFactory.stopInternalTracingCapture();
         PeerConnectionFactory.shutdownInternalTracer();
         videoContainer.setVisibility(View.GONE);
-        resetMediaButton();
+        resetMediaButtons();
     }
 
     private boolean isAudioMuted = false;
@@ -554,7 +552,7 @@ public final class NinchatWebRTCView implements PeerConnection.Observer, SdpObse
     /**
      * Reset media view state
      */
-    public void resetMediaButton() {
+    public void resetMediaButtons() {
         final ImageView microphoneImage = videoContainer.findViewById(R.id.microphone_on_off);
         final ImageView audioImage = videoContainer.findViewById(R.id.audio_on_off);
         final ImageView videoImage = videoContainer.findViewById(R.id.video_on_off);

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/views/NinchatWebRTCView.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/views/NinchatWebRTCView.java
@@ -501,6 +501,7 @@ public final class NinchatWebRTCView implements PeerConnection.Observer, SdpObse
         PeerConnectionFactory.stopInternalTracingCapture();
         PeerConnectionFactory.shutdownInternalTracer();
         videoContainer.setVisibility(View.GONE);
+        resetMediaButton();
     }
 
     private boolean isAudioMuted = false;
@@ -539,8 +540,6 @@ public final class NinchatWebRTCView implements PeerConnection.Observer, SdpObse
         final ImageView image = videoContainer.findViewById(R.id.microphone_on_off);
         image.setImageResource(isMicrophoneMuted ? R.drawable.ninchat_icon_video_microphone_off : R.drawable.ninchat_icon_video_microphone_on);
         localAudioTrack.setEnabled(!isMicrophoneMuted);
-        AudioManager audioManager = (AudioManager) videoContainer.getContext().getSystemService(Context.AUDIO_SERVICE);
-        audioManager.setMicrophoneMute(isMicrophoneMuted);
     }
 
     private boolean isVideoDisabled = false;
@@ -550,6 +549,18 @@ public final class NinchatWebRTCView implements PeerConnection.Observer, SdpObse
         final ImageView image = videoContainer.findViewById(R.id.video_on_off);
         image.setImageResource(isVideoDisabled ? R.drawable.ninchat_icon_video_camera_off : R.drawable.ninchat_icon_video_camera_on);
         localVideoTrack.setEnabled(!isVideoDisabled);
+    }
+
+    /**
+     * Reset media view state
+     */
+    public void resetMediaButton() {
+        final ImageView microphoneImage = videoContainer.findViewById(R.id.microphone_on_off);
+        final ImageView audioImage = videoContainer.findViewById(R.id.audio_on_off);
+        final ImageView videoImage = videoContainer.findViewById(R.id.video_on_off);
+        microphoneImage.setImageResource(R.drawable.ninchat_icon_video_microphone_on);
+        audioImage.setImageResource(R.drawable.ninchat_icon_video_sound_on);
+        videoImage.setImageResource(R.drawable.ninchat_icon_video_camera_on);
     }
 
     public void onResume() {


### PR DESCRIPTION
Always start media session with audio video-enabled and don't cache existing states

More info
- https://github.com/somia/mobile/issues/187