### PR TITLE
Refactor NinchatSession initialization

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ In order to use the SDK you need to create an instance of the `NinchatSession` c
     import com.ninchat.sdk.NinchatSession;
     ...
     NinchatSession.Builder builder = new NinchatSession.Builder(applicationContext, configurationKey);
-    NinchatSession session = builder.build();
+    NinchatSession session = builder.create();
 
 ### Starting the API client
 
@@ -108,7 +108,7 @@ builder.setConfiguration(ninchatConfiguration); // optional
 builder.setPreferredEnvironments(preferredEnvironments); // optional
 builder.setEventListener(eventListener); // optional
 builder.setLogListener(logListener); // optional
-NinchatSession session = builder.build();
+NinchatSession session = builder.create();
 ```
 
 See [Ninchat API Reference](https://github.com/ninchat/ninchat-api/blob/v2/api.md) for information about the API's outbound Actions and inbound Events.

--- a/README.md
+++ b/README.md
@@ -18,11 +18,12 @@ Then you need to add the following dependency to the project dependencies:
 
 ### Creating the API client
 
-In order to use the SDK you need to create an instance of the `NinchatSession` class. Its constructor takes the application context and configuration key as parameters:
+In order to use the SDK you need to create an instance of the `NinchatSession` class with `NinchatSession.Builder`. Its constructor takes the application context and configuration key as parameters:
 
     import com.ninchat.sdk.NinchatSession;
     ...
-    NinchatSession session = new NinchatSession(applicationContext, configurationKey, sessionCredentials);
+    NinchatSession.Builder builder = new NinchatSession.Builder(applicationContext, configurationKey);
+    NinchatSession session = builder.build();
 
 ### Starting the API client
 
@@ -42,12 +43,13 @@ As of 0.5.0 `onSessionInitiated` will return a `NinchatSessionCredentials` objec
 
 ### Setting metadata
 
-The `NinchatSession` class has a setter for audience metadata (i.e. user information).  It's specified as a `com.ninchat.client.Props` object:
+The `NinchatSession.Builder` class has a setter for audience metadata (i.e. user information).  It's specified as a `com.ninchat.client.Props` object:
 
     Props metadata = new Props();
     metadata.setString("Significant Information", someValue);
     metadata.setString("secure", secureMetadata);
-    session.setAudienceMetadata(metadata);
+    ...
+    builder.setAudienceMetadata(metadata);
 
 ### <a name="optionalparameters"></a>Optional parameters
 
@@ -76,6 +78,7 @@ The SDK exposes the low-level communication interface with the method `getSessio
 
 Furthermore, the host application can register itself (or its property/properties) as a listener to the low-level API events and/or logs by creating the `NinchatSession` instance with the listeners as constructor arguments:
 
+### Following constructors deprecated in 0.6.0
 ```
 session = new NinchatSession(applicationContext, configurationKey, sessionCredentials, eventListener);
 session = new NinchatSession(applicationContext, configurationKey, sessionCredentials, preferredEnvironments, eventListener);
@@ -96,6 +99,17 @@ session = new NinchatSession(applicationContext, configurationKey, sessionCreden
 The argument `eventListener`, when non-null, must be an instance of the `NinchatSDKEventListener` class, the `logListener` an instance of the `NinchatSDKLogListener`interface, and `ninchatConfiguration` is an instance of `NinchatConfiguration ` class.
 
 As of version 0.5.0 `sessionCredentials` can be added to open up a previous session. Passing `null` will open a new session. Passing invalid/outdated `sessionCredentials` will cause `onSessionInitFailed` to be invoked.
+
+As of version 0.6.0 aforementioned `NinchatSession` constructors are deprecated and a builder pattern has been introduced. `NinchatSession` object needs to be initialized the following way:
+```
+NinchatSession.Builder builder = new NinchatSession.Builder(applicationContext, configurationKey);
+builder.setSessionCredentials(sessionCredentials); // optional
+builder.setConfiguration(ninchatConfiguration); // optional
+builder.setPreferredEnvironments(preferredEnvironments); // optional
+builder.setEventListener(eventListener); // optional
+builder.setLogListener(logListener); // optional
+NinchatSession session = builder.build();
+```
 
 See [Ninchat API Reference](https://github.com/ninchat/ninchat-api/blob/v2/api.md) for information about the API's outbound Actions and inbound Events.
 

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSession.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSession.java
@@ -33,7 +33,7 @@ public final class NinchatSession {
             this.configurationKey = configurationKey;
         }
 
-        public NinchatSession build() {
+        public NinchatSession create() {
             return new NinchatSession(this);
         }
 

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSession.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSession.java
@@ -2,7 +2,9 @@ package com.ninchat.sdk;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.support.annotation.Nullable;
+import android.support.design.widget.BaseTransientBottomBar;
 
 import com.ninchat.client.Props;
 import com.ninchat.client.Session;
@@ -12,6 +14,66 @@ import com.ninchat.sdk.models.NinchatSessionCredentials;
  * Created by Jussi Pekonen (jussi.pekonen@qvik.fi) on 17/08/2018.
  */
 public final class NinchatSession {
+
+    public static final int NINCHAT_SESSION_REQUEST_CODE = NinchatSession.class.hashCode() & 0xffff;
+    private NinchatSessionManager sessionManager;
+    private String siteSecret = null;
+
+    public static class Builder {
+        private final Context context;
+        private final String configurationKey;
+        private NinchatSessionCredentials sessionCredentials;
+        private NinchatConfiguration configuration;
+        private String[] preferredEnvironments;
+        private NinchatSDKEventListener eventListener;
+        private NinchatSDKLogListener logListener;
+
+        public Builder(Context context, String configurationKey) {
+            this.context = context;
+            this.configurationKey = configurationKey;
+        }
+
+        public NinchatSession build() {
+            return new NinchatSession(this);
+        }
+
+        public Builder setSessionCredentials(NinchatSessionCredentials sessionCredentials) {
+            this.sessionCredentials = sessionCredentials;
+            return this;
+        }
+
+        public Builder setConfiguration(NinchatConfiguration configuration) {
+            this.configuration = configuration;
+            return this;
+        }
+
+        public Builder setPreferredEnvironments(String[] preferredEnvironments) {
+            this.preferredEnvironments = preferredEnvironments;
+            return this;
+        }
+
+        public Builder setEventListener(NinchatSDKEventListener eventListener) {
+            this.eventListener = eventListener;
+            return this;
+        }
+
+        public Builder setLogListener(NinchatSDKLogListener logListener) {
+            this.logListener = logListener;
+            return this;
+        }
+    }
+
+    private NinchatSession(Builder builder) {
+        Context context = builder.context;
+        String configurationKey = builder.configurationKey;
+        NinchatSessionCredentials sessionCredentials = builder.sessionCredentials;
+        NinchatConfiguration configuration = builder.configuration;
+        String[] preferredEnvironments = builder.preferredEnvironments;
+        NinchatSDKEventListener eventListener = builder.eventListener;
+        NinchatSDKLogListener logListener = builder.logListener;
+
+        this.sessionManager = NinchatSessionManager.init(context, configurationKey, sessionCredentials, configuration, preferredEnvironments, eventListener, logListener);
+    }
 
     public static final class Analytics {
 
@@ -35,68 +97,77 @@ public final class NinchatSession {
         public static final String START_FAILED = BuildConfig.LIBRARY_PACKAGE_NAME + ".START_FAILED";
     }
 
-    public static final int NINCHAT_SESSION_REQUEST_CODE = NinchatSession.class.hashCode() & 0xffff;
-
-    private NinchatSessionManager sessionManager;
-    private String siteSecret = null;
-
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials) {
         this(applicationContext, configurationKey, sessionCredentials, null, null, null, null);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final String[] preferredEnvironments) {
         this(applicationContext, configurationKey, sessionCredentials, null, preferredEnvironments, null, null);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatSDKEventListener eventListener) {
         this(applicationContext, configurationKey, sessionCredentials, null,null, eventListener, null);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final String[] preferredEnvironments, final NinchatSDKEventListener eventListener) {
         this(applicationContext, configurationKey, sessionCredentials, null, preferredEnvironments, eventListener, null);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatSDKLogListener logListener) {
         this(applicationContext, configurationKey, sessionCredentials, null, null, null, logListener);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final String[] preferredEnvironments, final NinchatSDKLogListener logListener) {
         this(applicationContext, configurationKey, sessionCredentials, null, preferredEnvironments, null, logListener);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatSDKEventListener eventListener, final NinchatSDKLogListener logListener) {
         this(applicationContext, configurationKey, sessionCredentials, null, null, eventListener, logListener);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatConfiguration ninchatConfiguration) {
         this(applicationContext, configurationKey, sessionCredentials, ninchatConfiguration, null, null, null);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatConfiguration ninchatConfiguration, final String[] preferredEnvironments) {
         this(applicationContext, configurationKey, sessionCredentials, ninchatConfiguration, preferredEnvironments, null, null);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatConfiguration ninchatConfiguration, final NinchatSDKEventListener eventListener) {
         this(applicationContext, configurationKey, sessionCredentials, ninchatConfiguration,null, eventListener, null);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatConfiguration ninchatConfiguration, final NinchatSDKLogListener logListener) {
         this(applicationContext, configurationKey, sessionCredentials, ninchatConfiguration, null, null, logListener);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatConfiguration ninchatConfiguration, final String[] preferredEnvironments, final NinchatSDKEventListener eventListener) {
         this(applicationContext, configurationKey, sessionCredentials, ninchatConfiguration, preferredEnvironments, eventListener, null);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatConfiguration ninchatConfiguration, final String[] preferredEnvironments, final NinchatSDKLogListener logListener) {
         this(applicationContext, configurationKey, sessionCredentials, ninchatConfiguration, preferredEnvironments, null, logListener);
     }
 
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, final NinchatConfiguration ninchatConfiguration, final NinchatSDKEventListener eventListener, final NinchatSDKLogListener logListener) {
         this(applicationContext, configurationKey, sessionCredentials, ninchatConfiguration, null, eventListener, logListener);
     }
 
-
+    @Deprecated
     public NinchatSession(final Context applicationContext, final String configurationKey, @Nullable NinchatSessionCredentials sessionCredentials, @Nullable NinchatConfiguration configurationManager,
                           final String[] preferredEnvironments, final NinchatSDKEventListener eventListener, final NinchatSDKLogListener logListener) {
         this.sessionManager = NinchatSessionManager.init(applicationContext, configurationKey, sessionCredentials, configurationManager, preferredEnvironments, eventListener, logListener);


### PR DESCRIPTION
Implement builder pattern for `NinchatSession` initialization. All parameters previously required in`NinchatSession` constructor are now set via Builder. `setAppDetails` `setServerAddress` `setSiteSecret` `setAudienceMetadata` have not been modified.