### PR TITLE
Re factor ninchat message adapter

### DIFF
--- a/ninchatsdk/build.gradle
+++ b/ninchatsdk/build.gradle
@@ -50,7 +50,9 @@ android {
     }
 
     testOptions {
-        unitTests.includeAndroidResources = true
+        unitTests {
+            includeAndroidResources = true
+        }
     }
 }
 
@@ -64,9 +66,11 @@ dependencies {
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.mockito:mockito-android:3.3.3'
     testImplementation 'org.mockito:mockito-core:3.3.3'
+    testImplementation 'org.robolectric:robolectric:4.3'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+
 }
 
 apply plugin: 'maven'

--- a/ninchatsdk/build.gradle
+++ b/ninchatsdk/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.3.3'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 apply plugin: 'maven'

--- a/ninchatsdk/build.gradle
+++ b/ninchatsdk/build.gradle
@@ -66,7 +66,7 @@ dependencies {
     testImplementation 'org.mockito:mockito-core:3.3.3'
     androidTestImplementation 'com.android.support.test:runner:1.0.2'
     androidTestImplementation 'com.android.support.test.espresso:espresso-core:3.0.2'
-    implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
+    testImplementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"
 }
 
 apply plugin: 'maven'

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSessionManager.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSessionManager.java
@@ -817,14 +817,14 @@ public final class NinchatSessionManager {
                         for (int k = 0; k < options.length(); ++k) {
                             messageOptions.add(new NinchatOption(options.getJSONObject(k)));
                         }
-                        messageAdapter.add(messageId, new NinchatMessage(NinchatMessage.Type.MULTICHOICE, sender, message.getString("label"), message, messageOptions, timestampMs));
+                        messageAdapter.addMessage(messageId, new NinchatMessage(NinchatMessage.Type.MULTICHOICE, sender, message.getString("label"), message, messageOptions, timestampMs));
                     } else {
                         simpleButtonChoice = true;
                         messageOptions.add(new NinchatOption(message));
                     }
                 }
                 if (simpleButtonChoice) {
-                    messageAdapter.add(messageId, new NinchatMessage(NinchatMessage.Type.MULTICHOICE, sender,null,  null, messageOptions, timestampMs));
+                    messageAdapter.addMessage(messageId, new NinchatMessage(NinchatMessage.Type.MULTICHOICE, sender,null,  null, messageOptions, timestampMs));
                 }
             } catch (final JSONException e) {
                 // Ignore message
@@ -853,7 +853,7 @@ public final class NinchatSessionManager {
                         NinchatDescribeFileTask.start(fileId);
                     }
                 } else {
-                    messageAdapter.add(messageId, new NinchatMessage(message.getString("text"), null, sender, timestampMs, !sender.equals(userId)));
+                    messageAdapter.addMessage(messageId, new NinchatMessage(message.getString("text"), null, sender, timestampMs, !sender.equals(userId)));
                 }
             } catch (final JSONException e) {
                 // Ignore
@@ -914,7 +914,7 @@ public final class NinchatSessionManager {
         file.setHeight(height);
         file.setDownloadableFile(width == -1 || height == -1);
 
-        messageAdapter.add(file.getMessageId(), new NinchatMessage(null, fileId, file.getSender(), file.getTimestamp(), file.isRemote()));
+        messageAdapter.addMessage(file.getMessageId(), new NinchatMessage(null, fileId, file.getSender(), file.getTimestamp(), file.isRemote()));
     }
 
     private void memberUpdated(final Props params) {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSessionManager.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSessionManager.java
@@ -500,7 +500,7 @@ public final class NinchatSessionManager {
         }
         queues.clear();
         if (ninchatQueueListAdapter != null) {
-            ninchatQueueListAdapter.clear();
+            ninchatQueueListAdapter.clearData();
         }
         final List<String> openQueues = getAudienceQueues();
         for (String queueId : parser.properties.keySet()) {
@@ -550,7 +550,7 @@ public final class NinchatSessionManager {
             ninchatQueue.setClosed(closed);
             queues.add(ninchatQueue);
             if (ninchatQueueListAdapter != null) {
-                ninchatQueueListAdapter.addQueue(ninchatQueue);
+                ninchatQueueListAdapter.addData(ninchatQueue);
             }
         }
         final Context context = contextWeakReference.get();

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/activities/NinchatChatActivity.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/activities/NinchatChatActivity.java
@@ -540,7 +540,7 @@ public final class NinchatChatActivity extends NinchatBaseActivity {
         pip.setLayoutParams(pipLayoutParams);
 
         webRTCView.onResume();
-        messageAdapter.scrollToBottom(false);
+        messageAdapter.scrollToBottom(true);
     }
 
     // Reinitialize webRTC on hangup for possible new connection
@@ -578,7 +578,7 @@ public final class NinchatChatActivity extends NinchatBaseActivity {
                 // Update video height and cache current rootview height
                 videoContainer.setLayoutParams(layoutParams);
                 // push messages on top of soft keyboard
-                messageAdapter.scrollToBottom(false);
+                messageAdapter.scrollToBottom(true);
             }
             rootViewHeight = activityRootView.getHeight();
         });

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
@@ -46,27 +46,21 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
 
     public void addWriting(final String sender) {
         final String writingId = WRITING_MESSAGE_ID_PREFIX + sender;
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                final int index = ninchatMessageList.add(writingId, new NinchatMessage(NinchatMessage.Type.WRITING, sender, System.currentTimeMillis()));
-                messagesUpdated(index, false, false);
-            }
+        new Handler(Looper.getMainLooper()).post(() -> {
+            final int index = ninchatMessageList.add(writingId, new NinchatMessage(NinchatMessage.Type.WRITING, sender, System.currentTimeMillis()));
+            messagesUpdated(index, false, false);
         });
     }
 
-    public void add(final String messageId, final NinchatMessage message) {
+    public void addMessage(final String messageId, final NinchatMessage message) {
         if (ninchatMessageList.contains(messageId)) {
             return;
         }
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                final int oldNumberOfMessages = ninchatMessageList.size();
-                ninchatMessageList.remove(WRITING_MESSAGE_ID_PREFIX, message.getSenderId());
-                final int index = ninchatMessageList.add(messageId, message);
-                messagesUpdated(index, ninchatMessageList.size() == oldNumberOfMessages, false);
-            }
+        new Handler(Looper.getMainLooper()).post(() -> {
+            final int oldNumberOfMessages = ninchatMessageList.size();
+            ninchatMessageList.remove(WRITING_MESSAGE_ID_PREFIX, message.getSenderId());
+            final int index = ninchatMessageList.add(messageId, message);
+            messagesUpdated(index, ninchatMessageList.size() == oldNumberOfMessages, false);
         });
     }
 
@@ -75,12 +69,9 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
     }
 
     public void addMetaMessage(final String messageId, final String message) {
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                final int index = ninchatMessageList.add(messageId, new NinchatMessage(NinchatMessage.Type.META, message, System.currentTimeMillis()));
-                messagesUpdated(index, false, false);
-            }
+        new Handler(Looper.getMainLooper()).post(() -> {
+            final int index = ninchatMessageList.add(messageId, new NinchatMessage(NinchatMessage.Type.META, message, System.currentTimeMillis()));
+            messagesUpdated(index, false, false);
         });
     }
 
@@ -90,13 +81,10 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
 
     public void removeWritingMessage(final String sender) {
         final String writingId = WRITING_MESSAGE_ID_PREFIX + sender;
-        new Handler(Looper.getMainLooper()).post(new Runnable() {
-            @Override
-            public void run() {
-                final int position = ninchatMessageList.getPosition(writingId);
-                ninchatMessageList.remove(null, writingId);
-                messagesUpdated(position, false, true);
-            }
+        new Handler(Looper.getMainLooper()).post(() -> {
+            final int position = ninchatMessageList.getPosition(writingId);
+            ninchatMessageList.remove(null, writingId);
+            messagesUpdated(position, false, true);
         });
     }
 
@@ -223,12 +211,12 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
         }
 
         @Override
-        public void onMultiChoiceOptionToggled(NinchatMessage message, int position) {
+        public void onOptionsToggled(NinchatMessage message, final int choiceIndex, final int position){
             final RecyclerView recyclerView = recyclerViewWeakReference.get();
             if (recyclerView != null) {
                 ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
             }
-            message.toggleOption(position);
+            message.toggleOption(choiceIndex);
             if (recyclerView == null || recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_IDLE) {
                 notifyItemChanged(position);
             } else {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
@@ -30,6 +30,7 @@ import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
 import com.ninchat.sdk.activities.NinchatChatActivity;
 import com.ninchat.sdk.activities.NinchatMediaActivity;
+import com.ninchat.sdk.helper.EndlessRecyclerViewScrollListener;
 import com.ninchat.sdk.models.NinchatFile;
 import com.ninchat.sdk.models.NinchatMessage;
 import com.ninchat.sdk.models.NinchatUser;
@@ -320,31 +321,7 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
         }
     }
 
-    protected class ScrollListener extends RecyclerView.OnScrollListener {
-
-        private boolean updateData = false;
-        private int index;
-        private boolean updated;
-        private boolean removed;
-
-        protected void setData(final int index, final boolean updated, final boolean removed) {
-            updateData = true;
-            this.index = index;
-            this.updated = updated;
-            this.removed = removed;
-        }
-
-        @Override
-        public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
-            if (recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_IDLE && updateData) {
-                messagesUpdated(index, updated, removed);
-                updateData = false;
-            }
-            super.onScrollStateChanged(recyclerView, newState);
-        }
-    }
-
-    protected ScrollListener scrollListener = new ScrollListener();
+    protected EndlessRecyclerViewScrollListener scrollListener = new EndlessRecyclerViewScrollListener((index, updated, removed) -> messagesUpdated(index, updated, removed));
 
     protected static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
 

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
@@ -30,7 +30,7 @@ import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
 import com.ninchat.sdk.activities.NinchatChatActivity;
 import com.ninchat.sdk.activities.NinchatMediaActivity;
-import com.ninchat.sdk.helper.EndlessRecyclerViewScrollListener;
+import com.ninchat.sdk.helper.NinchatEndlessRecyclerViewScrollListener;
 import com.ninchat.sdk.models.NinchatFile;
 import com.ninchat.sdk.models.NinchatMessage;
 import com.ninchat.sdk.models.NinchatUser;
@@ -321,7 +321,7 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
         }
     }
 
-    protected EndlessRecyclerViewScrollListener scrollListener = new EndlessRecyclerViewScrollListener((index, updated, removed) -> messagesUpdated(index, updated, removed));
+    protected NinchatEndlessRecyclerViewScrollListener scrollListener = new NinchatEndlessRecyclerViewScrollListener((index, updated, removed) -> messagesUpdated(index, updated, removed));
 
     protected static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
 

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
@@ -1,41 +1,20 @@
 package com.ninchat.sdk.adapters;
 
-import android.graphics.Rect;
-import android.graphics.drawable.AnimationDrawable;
 import android.os.Handler;
 import android.os.Looper;
-import android.support.annotation.DrawableRes;
-import android.support.annotation.IdRes;
 import android.support.annotation.NonNull;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
 import android.support.v7.widget.SimpleItemAnimator;
-import android.text.Spanned;
-import android.text.TextUtils;
-import android.text.method.LinkMovementMethod;
-import android.text.util.Linkify;
-import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
-import android.widget.Button;
 import android.widget.EditText;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
-import android.widget.TextView;
 
-import com.ninchat.sdk.GlideApp;
-import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
 import com.ninchat.sdk.activities.NinchatChatActivity;
-import com.ninchat.sdk.activities.NinchatMediaActivity;
+import com.ninchat.sdk.adapters.holders.NinchatMessageViewHolder;
 import com.ninchat.sdk.helper.NinchatEndlessRecyclerViewScrollListener;
-import com.ninchat.sdk.models.NinchatFile;
 import com.ninchat.sdk.models.NinchatMessage;
-import com.ninchat.sdk.models.NinchatUser;
-
-import org.json.JSONException;
 
 import java.lang.ref.WeakReference;
 import java.text.SimpleDateFormat;
@@ -51,280 +30,9 @@ import java.util.Map;
 /**
  * Created by Jussi Pekonen (jussi.pekonen@qvik.fi) on 22/08/2018.
  */
-public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMessageAdapter.NinchatMessageViewHolder> {
-
-    public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
-
-        public NinchatMessageViewHolder(View itemView) {
-            super(itemView);
-        }
-
-        private void setAvatar(final ImageView avatar, final NinchatMessage ninchatMessage, final boolean hideAvatar) {
-            String userAvatar = null;
-            final NinchatUser user = NinchatSessionManager.getInstance().getMember(ninchatMessage.getSenderId());
-            if (user != null) {
-                userAvatar = user.getAvatar();
-            }
-            if (TextUtils.isEmpty(userAvatar)) {
-                userAvatar = NinchatSessionManager.getInstance().getDefaultAvatar(ninchatMessage.isRemoteMessage());
-            }
-            if (!TextUtils.isEmpty(userAvatar)) {
-                GlideApp.with(itemView.getContext())
-                        .load(userAvatar)
-                        .circleCrop()
-                        .into(avatar);
-            }
-            final boolean showAvatars = NinchatSessionManager.getInstance().showAvatars(ninchatMessage.isRemoteMessage());
-            if (!showAvatars) {
-                avatar.setVisibility(View.GONE);
-            } else if (hideAvatar) {
-                avatar.setVisibility(showAvatars ? View.INVISIBLE : View.GONE);
-                return;
-            }
-        }
-
-        private void bindMessage(final @IdRes int wrapperId, final @IdRes int headerId, final @IdRes int senderId, final @IdRes int timestampId, final @IdRes int messageView, final @IdRes int imageId, final @IdRes int playIconId, final @IdRes int avatarId, final NinchatMessage ninchatMessage, final boolean isContinuedMessage, int firstMessageBackground, final @DrawableRes int repeatedMessageBackground) {
-            itemView.findViewById(wrapperId).setVisibility(View.VISIBLE);
-            itemView.findViewById(headerId).setVisibility(View.GONE);
-
-            final TextView sender = itemView.findViewById(senderId);
-            String senderNameOverride = NinchatSessionManager.getInstance().getName(senderId == R.id.ninchat_chat_message_agent_name);
-            sender.setText(senderNameOverride != null ? senderNameOverride : ninchatMessage.getSender());
-
-            final TextView timestamp = itemView.findViewById(timestampId);
-            timestamp.setText(TIMESTAMP_FORMATTER.format(ninchatMessage.getTimestamp()));
-            setAvatar(itemView.findViewById(avatarId), ninchatMessage, isContinuedMessage);
-            final TextView message = itemView.findViewById(messageView);
-            message.setVisibility(View.GONE);
-            final Spanned messageContent = ninchatMessage.getMessage();
-            final NinchatFile file = NinchatSessionManager.getInstance().getFile(ninchatMessage.getFileId());
-            final ImageView image = itemView.findViewById(imageId);
-            image.setVisibility(View.GONE);
-            final View playIcon = itemView.findViewById(playIconId);
-            playIcon.setVisibility(View.GONE);
-            GlideApp.with(image.getContext()).clear(image);
-            image.setBackground(null);
-            if (messageContent != null) {
-                message.setVisibility(View.VISIBLE);
-                message.setAutoLinkMask(Linkify.ALL);
-                message.setText(messageContent);
-            } else if (file.isDownloadableFile()) {
-                message.setVisibility(View.VISIBLE);
-                message.setText(file.getFileLink());
-                message.setMovementMethod(LinkMovementMethod.getInstance());
-            } else {
-                final int width = file.getWidth();
-                final int height = file.getHeight();
-                final float density = itemView.getResources().getDisplayMetrics().density;
-                image.getLayoutParams().width = (int) (width * density);
-                image.getLayoutParams().height = (int) (height * density);
-                image.setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
-                image.setVisibility(View.VISIBLE);
-                GlideApp.with(image.getContext())
-                        .load(file.getUrl())
-                        .placeholder(R.color.ninchat_colorPrimaryDark)
-                        .override(width, height)
-                        .into(image);
-                if (file.isVideo()) {
-                    playIcon.setVisibility(View.VISIBLE);
-                }
-                image.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        v.getContext().startActivity(NinchatMediaActivity.getLaunchIntent(v.getContext(), ninchatMessage.getFileId()));
-                    }
-                });
-            }
-            itemView.findViewById(messageView).setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
-            if (isContinuedMessage) {
-                itemView.findViewById(wrapperId).setPadding(0, 0, 0, 0);
-            } else {
-                itemView.findViewById(headerId).setVisibility(View.VISIBLE);
-            }
-        }
-
-        void bind(final NinchatMessage data, final boolean isContinuedMessage) {
-            if (data.getType() == NinchatMessage.Type.PADDING) {
-                itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.VISIBLE);
-            } else if (data.getType() == NinchatMessage.Type.META) {
-                itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-                final TextView start = itemView.findViewById(R.id.ninchat_chat_message_meta);
-                start.setText(data.getMessage());
-                start.setVisibility(View.VISIBLE);
-            } else if (data.getType() == NinchatMessage.Type.END) {
-                itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-                final TextView end = itemView.findViewById(R.id.ninchat_chat_message_end_text);
-                end.setText(NinchatSessionManager.getInstance().getChatEnded());
-                final Button closeButton = itemView.findViewById(R.id.ninchat_chat_message_close);
-                closeButton.setText(NinchatSessionManager.getInstance().getCloseChat());
-                closeButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        final NinchatChatActivity activity = activityWeakReference.get();
-                        if (activity != null) {
-                            activity.chatClosed();
-                        }
-                    }
-                });
-                itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.VISIBLE);
-            } else if (data.getType().equals(NinchatMessage.Type.WRITING)) {
-                itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
-                setAvatar(itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_message).setVisibility(View.GONE);
-
-                String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
-                final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
-                agentName.setText(agentNameOverride != null ? agentNameOverride : data.getSender());
-
-                itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper)
-                        .setBackgroundResource(isContinuedMessage ?
-                                R.drawable.ninchat_chat_bubble_left_repeated :
-                                R.drawable.ninchat_chat_bubble_left);
-                final ImageView image = itemView.findViewById(R.id.ninchat_chat_message_agent_writing);
-                image.setVisibility(View.VISIBLE);
-                GlideApp.with(image.getContext()).clear(image);
-                image.setBackgroundResource(R.drawable.ninchat_icon_chat_writing_indicator);
-                final AnimationDrawable animationDrawable = (AnimationDrawable) image.getBackground();
-                animationDrawable.start();
-                if (isContinuedMessage) {
-                    itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
-                }
-            } else if (data.getType().equals(NinchatMessage.Type.MULTICHOICE)) {
-                itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
-                setAvatar(itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
-
-                String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
-                final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
-                agentName.setText(agentNameOverride != null ? agentNameOverride : data.getSender());
-
-                itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper)
-                        .setBackgroundResource(isContinuedMessage ?
-                                R.drawable.ninchat_chat_bubble_left_repeated :
-                                R.drawable.ninchat_chat_bubble_left);
-                final TextView message = itemView.findViewById(R.id.ninchat_chat_message_agent_message);
-                final Spanned messageText = data.getMessage();
-                message.setText(messageText);
-                message.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.VISIBLE);
-                final RecyclerView options = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_options);
-                options.setLayoutManager(messageText != null ? new LinearLayoutManager(itemView.getContext()) : new GridLayoutManager(itemView.getContext(), 2));
-                if (messageText == null) {
-                    options.addItemDecoration(new RecyclerView.ItemDecoration() {
-                        @Override
-                        public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
-                            outRect.top = 0;
-                            outRect.bottom = 0;
-                            if (parent.getChildLayoutPosition(view) % 2 == 0) {
-                                outRect.left = 0;
-                                outRect.right = 2;
-                            } else {
-                                outRect.left = 2;
-                                outRect.right = 0;
-                            }
-                        }
-                    });
-                }
-                options.setAdapter(new NinchatMultiChoiceAdapter(data, this, messageText == null));
-                final Button sendButton = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_send);
-                sendButton.setText(NinchatSessionManager.getInstance().getSubmitButtonText());
-                sendButton.setOnClickListener(new View.OnClickListener() {
-                    @Override
-                    public void onClick(View v) {
-                        try {
-                            NinchatSessionManager.getInstance().sendUIAction(data.getMultiChoiceData());
-                        } catch (final JSONException e) {
-                            Log.e(NinchatMessageAdapter.class.getSimpleName(), "Error when sending multichoice answer!", e);
-                        }
-                    }
-                });
-                sendButton.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper).getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
-                if (isContinuedMessage) {
-                    itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
-                }
-            } else if (data.isRemoteMessage()) {
-                itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
-                bindMessage(R.id.ninchat_chat_message_agent,
-                        R.id.ninchat_chat_message_agent_title,
-                        R.id.ninchat_chat_message_agent_name,
-                        R.id.ninchat_chat_message_agent_timestamp,
-                        R.id.ninchat_chat_message_agent_message,
-                        R.id.ninchat_chat_message_agent_image,
-                        R.id.ninchat_chat_message_agent_video_play_image,
-                        R.id.ninchat_chat_message_agent_avatar,
-                        data, isContinuedMessage,
-                        R.drawable.ninchat_chat_bubble_left,
-                        R.drawable.ninchat_chat_bubble_left_repeated);
-            } else {
-                itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-                itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-                bindMessage(R.id.ninchat_chat_message_user,
-                        R.id.ninchat_chat_message_user_title,
-                        R.id.ninchat_chat_message_user_name,
-                        R.id.ninchat_chat_message_user_timestamp,
-                        R.id.ninchat_chat_message_user_message,
-                        R.id.ninchat_chat_message_user_image,
-                        R.id.ninchat_chat_message_user_video_play_image,
-                        R.id.ninchat_chat_message_user_avatar,
-                        data, isContinuedMessage,
-                        R.drawable.ninchat_chat_bubble_right,
-                        R.drawable.ninchat_chat_bubble_right_repeated);
-            }
-            final RecyclerView recyclerView = recyclerViewWeakReference.get();
-            if (recyclerView != null) {
-                ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(true);
-            }
-        }
-
-        public void optionToggled(final NinchatMessage message, final int position) {
-            final RecyclerView recyclerView = recyclerViewWeakReference.get();
-            if (recyclerView != null) {
-                ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
-            }
-            message.toggleOption(position);
-            if (recyclerView == null || recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_IDLE) {
-                notifyItemChanged(getAdapterPosition());
-            } else {
-                scrollListener.setData(getAdapterPosition(), true, false);
-            }
-        }
-    }
+public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMessageViewHolder> {
 
     protected NinchatEndlessRecyclerViewScrollListener scrollListener = new NinchatEndlessRecyclerViewScrollListener((index, updated, removed) -> messagesUpdated(index, updated, removed));
-
-    protected static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
-
     protected WeakReference<NinchatChatActivity> activityWeakReference;
     protected WeakReference<RecyclerView> recyclerViewWeakReference;
     protected List<String> messageIds;
@@ -511,7 +219,39 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
     @NonNull
     @Override
     public NinchatMessageViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
-        return new NinchatMessageViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_chat_message, parent, false));
+        return new NinchatMessageViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_chat_message, parent, false),
+                scrollListener,
+                new NinchatMessageViewHolder.Callback() {
+                    @Override
+                    public void onClickListener() {
+                        final NinchatChatActivity activity = activityWeakReference.get();
+                        if (activity != null) {
+                            activity.chatClosed();
+                        }
+                    }
+
+                    @Override
+                    public void onRequiredAnimationChange() {
+                        final RecyclerView recyclerView = recyclerViewWeakReference.get();
+                        if (recyclerView != null) {
+                            ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(true);
+                        }
+                    }
+
+                    @Override
+                    public void onOptionToggled(NinchatMessage message, int position) {
+                        final RecyclerView recyclerView = recyclerViewWeakReference.get();
+                        if (recyclerView != null) {
+                            ((SimpleItemAnimator) recyclerView.getItemAnimator()).setSupportsChangeAnimations(false);
+                        }
+                        message.toggleOption(position);
+                        if (recyclerView == null || recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_IDLE) {
+                            notifyItemChanged(position);
+                        } else {
+                            scrollListener.setData(position, true, false);
+                        }
+                    }
+                });
     }
 
     @Override
@@ -530,4 +270,5 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
             holder.bind(message, isContinuedMessage);
         }
     }
+
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
@@ -17,13 +17,11 @@ import com.ninchat.sdk.helper.NinchatEndlessRecyclerViewScrollListener;
 import com.ninchat.sdk.models.NinchatMessage;
 
 import java.lang.ref.WeakReference;
-import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.ListIterator;
-import java.util.Locale;
 import java.util.Map;
 
 
@@ -220,7 +218,6 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
     @Override
     public NinchatMessageViewHolder onCreateViewHolder(@NonNull ViewGroup parent, int viewType) {
         return new NinchatMessageViewHolder(LayoutInflater.from(parent.getContext()).inflate(R.layout.item_chat_message, parent, false),
-                scrollListener,
                 new NinchatMessageViewHolder.Callback() {
                     @Override
                     public void onClickListener() {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMultiChoiceAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMultiChoiceAdapter.java
@@ -1,15 +1,10 @@
 package com.ninchat.sdk.adapters;
 
-import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
-import android.util.Log;
 import android.view.LayoutInflater;
-import android.view.View;
 import android.view.ViewGroup;
-import android.widget.TextView;
 
-import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
 import com.ninchat.sdk.adapters.holders.NinchatMessageViewHolder;
 import com.ninchat.sdk.adapters.holders.NinchatMultiChoiceViewholder;
@@ -56,10 +51,10 @@ public final class NinchatMultiChoiceAdapter extends RecyclerView.Adapter<Nincha
 
     private final NinchatMultiChoiceViewholder.Callback callback = new NinchatMultiChoiceViewholder.Callback() {
         @Override
-        public void onClickListener(NinchatMessage message, int position) {
+        public void onMultiChoiceOptionToggled(NinchatMessage message, int position) {
             final NinchatMessageViewHolder viewHolder = viewHolderWeakReference.get();
             if (viewHolder != null) {
-                viewHolder.optionToggled(message, position);
+                viewHolder.onMultiChoiceOptionToggled(message, position);
             }
         }
     };

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMultiChoiceAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMultiChoiceAdapter.java
@@ -9,51 +9,21 @@ import android.widget.TextView;
 
 import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
+import com.ninchat.sdk.adapters.holders.NinchatMessageViewHolder;
+import com.ninchat.sdk.adapters.holders.NinchatMultiChoiceViewholder;
 import com.ninchat.sdk.models.NinchatMessage;
 import com.ninchat.sdk.models.NinchatOption;
 
 import java.lang.ref.WeakReference;
 import java.util.List;
 
-public final class NinchatMultiChoiceAdapter extends RecyclerView.Adapter<NinchatMultiChoiceAdapter.NinchatMultiChoiceViewholder> {
-
-    public final class NinchatMultiChoiceViewholder extends RecyclerView.ViewHolder {
-        public NinchatMultiChoiceViewholder(@NonNull View itemView, final NinchatMessage message) {
-            super(itemView);
-        }
-
-        public void bind(final NinchatMessage message, final int position, final boolean sendAction) {
-            final TextView button = (TextView) itemView;
-            final List<NinchatOption> options = message.getOptions();
-            final NinchatOption option = options.get(position);
-            button.setText(option.getLabel());
-            button.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    if (sendAction) {
-                        try {
-                            option.toggle();
-                            NinchatSessionManager.getInstance().sendUIAction(option.toJSON());
-                            option.toggle();
-                        } catch (final Exception e) {
-                            // Ignore
-                        }
-                    } else {
-                        final NinchatMessageAdapter.NinchatMessageViewHolder viewHolder = viewHolderWeakReference.get();
-                        if (viewHolder != null) {
-                            viewHolder.optionToggled(message, position);
-                        }
-                    }
-                }
-            });
-        }
-    }
+public final class NinchatMultiChoiceAdapter extends RecyclerView.Adapter<NinchatMultiChoiceViewholder> {
 
     private NinchatMessage message;
-    private WeakReference<NinchatMessageAdapter.NinchatMessageViewHolder> viewHolderWeakReference;
+    private WeakReference<NinchatMessageViewHolder> viewHolderWeakReference;
     private boolean sendActionImmediately;
 
-    public NinchatMultiChoiceAdapter(final NinchatMessage message, final NinchatMessageAdapter.NinchatMessageViewHolder viewHolder, final boolean sendActionImmediately) {
+    public NinchatMultiChoiceAdapter(final NinchatMessage message, final NinchatMessageViewHolder viewHolder, final boolean sendActionImmediately) {
         this.message = message;
         this.viewHolderWeakReference = new WeakReference<>(viewHolder);
         this.sendActionImmediately = sendActionImmediately;
@@ -68,7 +38,15 @@ public final class NinchatMultiChoiceAdapter extends RecyclerView.Adapter<Nincha
     @Override
     public NinchatMultiChoiceViewholder onCreateViewHolder(@NonNull ViewGroup viewGroup, int position) {
         final NinchatOption option = message.getOptions().get(position);
-        return new NinchatMultiChoiceViewholder(LayoutInflater.from(viewGroup.getContext()).inflate(option.isSelected() ? R.layout.item_chat_multichoice_selected : R.layout.item_chat_multichoice_unselected, viewGroup, false), message);
+        return new NinchatMultiChoiceViewholder(LayoutInflater.from(viewGroup.getContext()).inflate(option.isSelected() ? R.layout.item_chat_multichoice_selected : R.layout.item_chat_multichoice_unselected, viewGroup, false), new NinchatMultiChoiceViewholder.Callback() {
+            @Override
+            public void onClickListener(NinchatMessage message, int position) {
+                final NinchatMessageViewHolder viewHolder = viewHolderWeakReference.get();
+                if (viewHolder != null) {
+                    viewHolder.optionToggled(message, position);
+                }
+            }
+        });
     }
 
     @Override

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMultiChoiceAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMultiChoiceAdapter.java
@@ -40,7 +40,7 @@ public final class NinchatMultiChoiceAdapter extends RecyclerView.Adapter<Nincha
 
     @Override
     public void onBindViewHolder(@NonNull NinchatMultiChoiceViewholder ninchatMultiChoiceViewholder, int position) {
-        ninchatMultiChoiceViewholder.bind(message, position, sendActionImmediately, callback);
+        ninchatMultiChoiceViewholder.bind(message, sendActionImmediately, callback);
     }
 
     @Override
@@ -51,10 +51,11 @@ public final class NinchatMultiChoiceAdapter extends RecyclerView.Adapter<Nincha
 
     private final NinchatMultiChoiceViewholder.Callback callback = new NinchatMultiChoiceViewholder.Callback() {
         @Override
-        public void onMultiChoiceOptionToggled(NinchatMessage message, int position) {
+        public void onMultiChoiceOptionToggled(NinchatMessage message, final int choiceIndex) {
+            // notifyDataSetChanged();
             final NinchatMessageViewHolder viewHolder = viewHolderWeakReference.get();
             if (viewHolder != null) {
-                viewHolder.onMultiChoiceOptionToggled(message, position);
+                viewHolder.onMultiChoiceOptionToggled(message, choiceIndex);
             }
         }
     };

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMultiChoiceAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMultiChoiceAdapter.java
@@ -1,7 +1,9 @@
 package com.ninchat.sdk.adapters;
 
+import android.app.Activity;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.RecyclerView;
+import android.util.Log;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
@@ -38,20 +40,12 @@ public final class NinchatMultiChoiceAdapter extends RecyclerView.Adapter<Nincha
     @Override
     public NinchatMultiChoiceViewholder onCreateViewHolder(@NonNull ViewGroup viewGroup, int position) {
         final NinchatOption option = message.getOptions().get(position);
-        return new NinchatMultiChoiceViewholder(LayoutInflater.from(viewGroup.getContext()).inflate(option.isSelected() ? R.layout.item_chat_multichoice_selected : R.layout.item_chat_multichoice_unselected, viewGroup, false), new NinchatMultiChoiceViewholder.Callback() {
-            @Override
-            public void onClickListener(NinchatMessage message, int position) {
-                final NinchatMessageViewHolder viewHolder = viewHolderWeakReference.get();
-                if (viewHolder != null) {
-                    viewHolder.optionToggled(message, position);
-                }
-            }
-        });
+        return new NinchatMultiChoiceViewholder(LayoutInflater.from(viewGroup.getContext()).inflate(option.isSelected() ? R.layout.item_chat_multichoice_selected : R.layout.item_chat_multichoice_unselected, viewGroup, false));
     }
 
     @Override
     public void onBindViewHolder(@NonNull NinchatMultiChoiceViewholder ninchatMultiChoiceViewholder, int position) {
-        ninchatMultiChoiceViewholder.bind(message, position, sendActionImmediately);
+        ninchatMultiChoiceViewholder.bind(message, position, sendActionImmediately, callback);
     }
 
     @Override
@@ -59,4 +53,14 @@ public final class NinchatMultiChoiceAdapter extends RecyclerView.Adapter<Nincha
         final List<NinchatOption> options = message.getOptions();
         return options != null ? options.size() : 0;
     }
+
+    private final NinchatMultiChoiceViewholder.Callback callback = new NinchatMultiChoiceViewholder.Callback() {
+        @Override
+        public void onClickListener(NinchatMessage message, int position) {
+            final NinchatMessageViewHolder viewHolder = viewHolderWeakReference.get();
+            if (viewHolder != null) {
+                viewHolder.optionToggled(message, position);
+            }
+        }
+    };
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatBaseViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatBaseViewHolder.java
@@ -25,8 +25,8 @@ import java.util.Locale;
 import java.util.Date;
 
 public abstract class NinchatBaseViewHolder extends RecyclerView.ViewHolder {
-    private static final String TAG = NinchatBaseViewHolder.class.getSimpleName();
-    private static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
+    private final String TAG = NinchatBaseViewHolder.class.getSimpleName();
+    private final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
 
     NinchatBaseViewHolder(@NonNull View itemView) {
         super(itemView);
@@ -52,7 +52,6 @@ public abstract class NinchatBaseViewHolder extends RecyclerView.ViewHolder {
     ) {
         itemView.findViewById(wrapperId).setVisibility(View.VISIBLE);
         itemView.findViewById(headerId).setVisibility(View.GONE);
-
         updateSenderView(senderId, ninchatMessage.getSender());
         updateTimestamp(timestampId, ninchatMessage.getTimestamp());
 
@@ -63,12 +62,15 @@ public abstract class NinchatBaseViewHolder extends RecyclerView.ViewHolder {
 
         final TextView message = itemView.findViewById(messageView);
         message.setVisibility(View.GONE);
+
         final Spanned messageContent = ninchatMessage.getMessage();
         final NinchatFile file = NinchatSessionManager.getInstance().getFile(ninchatMessage.getFileId());
         final ImageView image = itemView.findViewById(imageId);
         image.setVisibility(View.GONE);
+
         final View playIcon = itemView.findViewById(playIconId);
         playIcon.setVisibility(View.GONE);
+
         GlideApp.with(image.getContext()).clear(image);
         image.setBackground(null);
         if (messageContent != null) {
@@ -93,12 +95,7 @@ public abstract class NinchatBaseViewHolder extends RecyclerView.ViewHolder {
             if (file.isVideo()) {
                 playIcon.setVisibility(View.VISIBLE);
             }
-            image.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    v.getContext().startActivity(NinchatMediaActivity.getLaunchIntent(v.getContext(), ninchatMessage.getFileId()));
-                }
-            });
+            image.setOnClickListener(v -> v.getContext().startActivity(NinchatMediaActivity.getLaunchIntent(v.getContext(), ninchatMessage.getFileId())));
         }
         itemView.findViewById(messageView).setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
         if (isContinuedMessage) {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatBaseViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatBaseViewHolder.java
@@ -1,0 +1,108 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.support.annotation.DrawableRes;
+import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.text.Spanned;
+import android.text.method.LinkMovementMethod;
+import android.text.util.Linkify;
+import android.util.Log;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.ninchat.sdk.GlideApp;
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.activities.NinchatMediaActivity;
+import com.ninchat.sdk.models.NinchatFile;
+import com.ninchat.sdk.models.NinchatMessage;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+public abstract class NinchatBaseViewHolder extends RecyclerView.ViewHolder {
+    private static final String TAG = NinchatBaseViewHolder.class.getSimpleName();
+
+    protected static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
+
+    NinchatBaseViewHolder(@NonNull View itemView) {
+        super(itemView);
+    }
+
+    public abstract void bind(final NinchatMessage data, final boolean isContinuedMessage) throws Exception;
+
+    public void bindMessage(
+            final @IdRes int wrapperId,
+            final @IdRes int headerId,
+            final @IdRes int senderId,
+            final @IdRes int timestampId,
+            final @IdRes int messageView,
+            final @IdRes int imageId,
+            final @IdRes int playIconId,
+            final @IdRes int avatarId,
+            final NinchatMessage ninchatMessage,
+            final boolean isContinuedMessage,
+            int firstMessageBackground,
+            @DrawableRes int repeatedMessageBackground
+    ) {
+        itemView.findViewById(wrapperId).setVisibility(View.VISIBLE);
+        itemView.findViewById(headerId).setVisibility(View.GONE);
+
+        final TextView sender = itemView.findViewById(senderId);
+        String senderNameOverride = NinchatSessionManager.getInstance().getName(senderId == R.id.ninchat_chat_message_agent_name);
+        sender.setText(senderNameOverride != null ? senderNameOverride : ninchatMessage.getSender());
+
+        final TextView timestamp = itemView.findViewById(timestampId);
+        timestamp.setText(TIMESTAMP_FORMATTER.format(ninchatMessage.getTimestamp()));
+        //ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(avatarId), ninchatMessage, isContinuedMessage);
+        final TextView message = itemView.findViewById(messageView);
+        message.setVisibility(View.GONE);
+        final Spanned messageContent = ninchatMessage.getMessage();
+        final NinchatFile file = NinchatSessionManager.getInstance().getFile(ninchatMessage.getFileId());
+        final ImageView image = itemView.findViewById(imageId);
+        image.setVisibility(View.GONE);
+        final View playIcon = itemView.findViewById(playIconId);
+        playIcon.setVisibility(View.GONE);
+        GlideApp.with(image.getContext()).clear(image);
+        image.setBackground(null);
+        if (messageContent != null) {
+            message.setVisibility(View.VISIBLE);
+            message.setAutoLinkMask(Linkify.ALL);
+            message.setText(messageContent);
+        } else if (file.isDownloadableFile()) {
+            message.setVisibility(View.VISIBLE);
+            message.setText(file.getFileLink());
+            message.setMovementMethod(LinkMovementMethod.getInstance());
+        } else {
+            final int width = file.getWidth();
+            final int height = file.getHeight();
+            final float density = itemView.getResources().getDisplayMetrics().density;
+            image.getLayoutParams().width = (int) (width * density);
+            image.getLayoutParams().height = (int) (height * density);
+            image.setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
+            image.setVisibility(View.VISIBLE);
+            GlideApp.with(image.getContext())
+                    .load(file.getUrl())
+                    .placeholder(R.color.ninchat_colorPrimaryDark)
+                    .override(width, height)
+                    .into(image);
+            if (file.isVideo()) {
+                playIcon.setVisibility(View.VISIBLE);
+            }
+            image.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    v.getContext().startActivity(NinchatMediaActivity.getLaunchIntent(v.getContext(), ninchatMessage.getFileId()));
+                }
+            });
+        }
+        itemView.findViewById(messageView).setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
+        if (isContinuedMessage) {
+            itemView.findViewById(wrapperId).setPadding(0, 0, 0, 0);
+        } else {
+            itemView.findViewById(headerId).setVisibility(View.VISIBLE);
+        }
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatBaseViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatBaseViewHolder.java
@@ -7,7 +7,6 @@ import android.support.v7.widget.RecyclerView;
 import android.text.Spanned;
 import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
-import android.util.Log;
 import android.view.View;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -31,8 +30,6 @@ public abstract class NinchatBaseViewHolder extends RecyclerView.ViewHolder {
     NinchatBaseViewHolder(@NonNull View itemView) {
         super(itemView);
     }
-
-    public abstract void bind(final NinchatMessage data, final boolean isContinuedMessage) throws Exception;
 
     // todo separate responsibilities
     public void bindMessage(

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatEndViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatEndViewHolder.java
@@ -1,0 +1,42 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.models.NinchatMessage;
+
+public class NinchatEndViewHolder extends NinchatBaseViewHolder {
+    private final NinchatMessageViewHolder.Callback callback;
+
+    public NinchatEndViewHolder(@NonNull View itemView, NinchatMessageViewHolder.Callback callback) {
+        super(itemView);
+        this.callback = callback;
+    }
+
+    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+        itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+        //todo fix ordering beautify
+        setEndText();
+        setButtonListener();
+        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.VISIBLE);
+
+    }
+
+    protected void setEndText() {
+        final TextView end = itemView.findViewById(R.id.ninchat_chat_message_end_text);
+        end.setText(NinchatSessionManager.getInstance().getChatEnded());
+    }
+
+    protected void setButtonListener() {
+        final Button closeButton = itemView.findViewById(R.id.ninchat_chat_message_close);
+        closeButton.setText(NinchatSessionManager.getInstance().getCloseChat());
+        closeButton.setOnClickListener(v -> callback.onClickListener());
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatEndViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatEndViewHolder.java
@@ -10,21 +10,18 @@ import com.ninchat.sdk.R;
 import com.ninchat.sdk.models.NinchatMessage;
 
 public class NinchatEndViewHolder extends NinchatBaseViewHolder {
-    private final NinchatMessageViewHolder.Callback callback;
-
-    public NinchatEndViewHolder(@NonNull View itemView, NinchatMessageViewHolder.Callback callback) {
+    public NinchatEndViewHolder(@NonNull View itemView) {
         super(itemView);
-        this.callback = callback;
     }
 
-    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+    public void bind(final NinchatMessageViewHolder.Callback callback) {
         itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
         //todo fix ordering beautify
         setEndText();
-        setButtonListener();
+        setButtonListener(callback);
         itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.VISIBLE);
 
     }
@@ -34,7 +31,7 @@ public class NinchatEndViewHolder extends NinchatBaseViewHolder {
         end.setText(NinchatSessionManager.getInstance().getChatEnded());
     }
 
-    protected void setButtonListener() {
+    protected void setButtonListener(final NinchatMessageViewHolder.Callback callback) {
         final Button closeButton = itemView.findViewById(R.id.ninchat_chat_message_close);
         closeButton.setText(NinchatSessionManager.getInstance().getCloseChat());
         closeButton.setOnClickListener(v -> callback.onClickListener());

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatEndViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatEndViewHolder.java
@@ -7,7 +7,6 @@ import android.widget.TextView;
 
 import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
-import com.ninchat.sdk.models.NinchatMessage;
 
 public class NinchatEndViewHolder extends NinchatBaseViewHolder {
     public NinchatEndViewHolder(@NonNull View itemView) {
@@ -19,11 +18,9 @@ public class NinchatEndViewHolder extends NinchatBaseViewHolder {
         itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-        //todo fix ordering beautify
+        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.VISIBLE);
         setEndText();
         setButtonListener(callback);
-        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.VISIBLE);
-
     }
 
     protected void setEndText() {
@@ -34,6 +31,6 @@ public class NinchatEndViewHolder extends NinchatBaseViewHolder {
     protected void setButtonListener(final NinchatMessageViewHolder.Callback callback) {
         final Button closeButton = itemView.findViewById(R.id.ninchat_chat_message_close);
         closeButton.setText(NinchatSessionManager.getInstance().getCloseChat());
-        closeButton.setOnClickListener(v -> callback.onClickListener());
+        closeButton.setOnClickListener(v -> callback.onChatClosed());
     }
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatGeneralViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatGeneralViewHolder.java
@@ -1,0 +1,36 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.support.annotation.NonNull;
+import android.text.Spanned;
+import android.view.View;
+import android.widget.TextView;
+
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.models.NinchatMessage;
+
+import org.jetbrains.annotations.NotNull;
+
+public class NinchatGeneralViewHolder extends NinchatBaseViewHolder {
+    public NinchatGeneralViewHolder(@NonNull View itemView) {
+        super(itemView);
+    }
+
+    public void bind(@NotNull final NinchatMessage data, final boolean isContinuedMessage) {
+        itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+        bindMessage(R.id.ninchat_chat_message_user,
+                R.id.ninchat_chat_message_user_title,
+                R.id.ninchat_chat_message_user_name,
+                R.id.ninchat_chat_message_user_timestamp,
+                R.id.ninchat_chat_message_user_message,
+                R.id.ninchat_chat_message_user_image,
+                R.id.ninchat_chat_message_user_video_play_image,
+                R.id.ninchat_chat_message_user_avatar,
+                data, isContinuedMessage,
+                R.drawable.ninchat_chat_bubble_right,
+                R.drawable.ninchat_chat_bubble_right_repeated);
+    }
+
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatGeneralViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatGeneralViewHolder.java
@@ -6,16 +6,20 @@ import android.view.View;
 import android.widget.TextView;
 
 import com.ninchat.sdk.R;
+import com.ninchat.sdk.helper.NinchatAvatar;
 import com.ninchat.sdk.models.NinchatMessage;
 
 import org.jetbrains.annotations.NotNull;
 
 public class NinchatGeneralViewHolder extends NinchatBaseViewHolder {
+
     public NinchatGeneralViewHolder(@NonNull View itemView) {
         super(itemView);
     }
 
-    public void bind(@NotNull final NinchatMessage data, final boolean isContinuedMessage) {
+    public void bind(@NotNull final NinchatMessage data,
+                     final NinchatAvatar ninchatAvatar,
+                     final boolean isContinuedMessage) {
         itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
@@ -30,7 +34,8 @@ public class NinchatGeneralViewHolder extends NinchatBaseViewHolder {
                 R.id.ninchat_chat_message_user_avatar,
                 data, isContinuedMessage,
                 R.drawable.ninchat_chat_bubble_right,
-                R.drawable.ninchat_chat_bubble_right_repeated);
+                R.drawable.ninchat_chat_bubble_right_repeated,
+                ninchatAvatar);
     }
 
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -45,7 +45,19 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
         ninchatAvatar = new NinchatAvatar();
     }
 
-    private void bindMessage(final @IdRes int wrapperId, final @IdRes int headerId, final @IdRes int senderId, final @IdRes int timestampId, final @IdRes int messageView, final @IdRes int imageId, final @IdRes int playIconId, final @IdRes int avatarId, final NinchatMessage ninchatMessage, final boolean isContinuedMessage, int firstMessageBackground, final @DrawableRes int repeatedMessageBackground) {
+    private void bindMessage(final @IdRes int wrapperId,
+                             final @IdRes int headerId,
+                             final @IdRes int senderId,
+                             final @IdRes int timestampId,
+                             final @IdRes int messageView,
+                             final @IdRes int imageId,
+                             final @IdRes int playIconId,
+                             final @IdRes int avatarId,
+                             final NinchatMessage ninchatMessage,
+                             final boolean isContinuedMessage,
+                             int firstMessageBackground,
+                             final @DrawableRes
+                             int repeatedMessageBackground) {
         itemView.findViewById(wrapperId).setVisibility(View.VISIBLE);
         itemView.findViewById(headerId).setVisibility(View.GONE);
 
@@ -145,7 +157,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
             itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
             itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
             itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
-            ninchatAvatar.setAvatar(itemView.getContext(),itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+            ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
             itemView.findViewById(R.id.ninchat_chat_message_agent_message).setVisibility(View.GONE);
 
             String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
@@ -174,7 +186,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
             itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
             itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
             itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
-            ninchatAvatar.setAvatar(itemView.getContext(),itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+            ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
 
             String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
             final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -8,9 +8,7 @@ import android.support.annotation.NonNull;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.support.v7.widget.SimpleItemAnimator;
 import android.text.Spanned;
-import android.text.TextUtils;
 import android.text.method.LinkMovementMethod;
 import android.text.util.Linkify;
 import android.util.Log;
@@ -21,18 +19,14 @@ import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.ninchat.sdk.GlideApp;
-import com.ninchat.sdk.GlideOptions;
 import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
-import com.ninchat.sdk.activities.NinchatChatActivity;
 import com.ninchat.sdk.activities.NinchatMediaActivity;
 import com.ninchat.sdk.adapters.NinchatMessageAdapter;
 import com.ninchat.sdk.adapters.NinchatMultiChoiceAdapter;
 import com.ninchat.sdk.helper.NinchatAvatar;
-import com.ninchat.sdk.helper.NinchatEndlessRecyclerViewScrollListener;
 import com.ninchat.sdk.models.NinchatFile;
 import com.ninchat.sdk.models.NinchatMessage;
-import com.ninchat.sdk.models.NinchatUser;
 
 import org.json.JSONException;
 

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -2,6 +2,7 @@ package com.ninchat.sdk.adapters.holders;
 
 import android.support.v7.widget.RecyclerView;
 import android.view.View;
+
 import com.ninchat.sdk.helper.NinchatAvatar;
 import com.ninchat.sdk.models.NinchatMessage;
 
@@ -49,15 +50,15 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
         this.callback.onRequiredAnimationChange();
     }
 
-    public void onMultiChoiceOptionToggled(final NinchatMessage message, final int position) {
-        this.callback.onMultiChoiceOptionToggled(message, position);
+    public void onMultiChoiceOptionToggled(final NinchatMessage message, final int choiceIndex) {
+        this.callback.onMultiChoiceOptionToggled(message, choiceIndex, getAdapterPosition());
     }
 
 
     public interface Callback {
         void onChatClosed();
 
-        void onMultiChoiceOptionToggled(final NinchatMessage message, final int position);
+        void onMultiChoiceOptionToggled(final NinchatMessage message, final int choiceIndex, final int position);
 
         void onRequiredAnimationChange();
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -5,12 +5,8 @@ import android.view.View;
 import com.ninchat.sdk.helper.NinchatAvatar;
 import com.ninchat.sdk.models.NinchatMessage;
 
-import java.text.SimpleDateFormat;
-import java.util.Locale;
-
 public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
-
-    protected static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
+    private final String TAG = NinchatMessageViewHolder.class.getSimpleName();
     protected final NinchatAvatar ninchatAvatar;
     protected final NinchatPaddingViewHolder paddingViewHolder;
     protected final NinchatMetaViewHolder metaViewHolder;
@@ -27,28 +23,28 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
         ninchatAvatar = new NinchatAvatar();
         paddingViewHolder = new NinchatPaddingViewHolder(itemView);
         metaViewHolder = new NinchatMetaViewHolder(itemView);
-        endViewHolder = new NinchatEndViewHolder(itemView, callback);
-        writingViewHolder = new NinchatWritingViewHolder(itemView, ninchatAvatar);
-        multipleChoiceViewHolder = new NinchatMultipleChoiceViewHolder(itemView, ninchatAvatar, callback);
-        remoteMessageViewHolder = new NinchatRemoteMessageViewHolder(itemView, callback);
+        endViewHolder = new NinchatEndViewHolder(itemView);
+        writingViewHolder = new NinchatWritingViewHolder(itemView);
+        multipleChoiceViewHolder = new NinchatMultipleChoiceViewHolder(itemView);
+        remoteMessageViewHolder = new NinchatRemoteMessageViewHolder(itemView);
         generalViewHolder = new NinchatGeneralViewHolder(itemView);
     }
 
     public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
         if (data.getType() == NinchatMessage.Type.PADDING) {
-            paddingViewHolder.bind(data, false);
+            paddingViewHolder.bind();
         } else if (data.getType() == NinchatMessage.Type.META) {
-            metaViewHolder.bind(data, false);
+            metaViewHolder.bind(data);
         } else if (data.getType() == NinchatMessage.Type.END) {
-            endViewHolder.bind(data, false);
+            endViewHolder.bind(callback);
         } else if (data.getType().equals(NinchatMessage.Type.WRITING)) {
-            writingViewHolder.bind(data, isContinuedMessage);
+            writingViewHolder.bind(data, ninchatAvatar, this, isContinuedMessage);
         } else if (data.getType().equals(NinchatMessage.Type.MULTICHOICE)) {
-            multipleChoiceViewHolder.bind(data, isContinuedMessage);
+            multipleChoiceViewHolder.bind(data, ninchatAvatar, this, isContinuedMessage);
         } else if (data.isRemoteMessage()) {
-            remoteMessageViewHolder.bind(data, isContinuedMessage);
+            remoteMessageViewHolder.bind(data, ninchatAvatar, isContinuedMessage);
         } else {
-            generalViewHolder.bind(data, isContinuedMessage);
+            generalViewHolder.bind(data, ninchatAvatar, isContinuedMessage);
         }
         this.callback.onRequiredAnimationChange();
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -1,0 +1,307 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.graphics.Rect;
+import android.graphics.drawable.AnimationDrawable;
+import android.support.annotation.DrawableRes;
+import android.support.annotation.IdRes;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.support.v7.widget.SimpleItemAnimator;
+import android.text.Spanned;
+import android.text.TextUtils;
+import android.text.method.LinkMovementMethod;
+import android.text.util.Linkify;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.ninchat.sdk.GlideApp;
+import com.ninchat.sdk.GlideOptions;
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.activities.NinchatChatActivity;
+import com.ninchat.sdk.activities.NinchatMediaActivity;
+import com.ninchat.sdk.adapters.NinchatMessageAdapter;
+import com.ninchat.sdk.adapters.NinchatMultiChoiceAdapter;
+import com.ninchat.sdk.helper.NinchatEndlessRecyclerViewScrollListener;
+import com.ninchat.sdk.models.NinchatFile;
+import com.ninchat.sdk.models.NinchatMessage;
+import com.ninchat.sdk.models.NinchatUser;
+
+import org.json.JSONException;
+
+import java.text.SimpleDateFormat;
+import java.util.Locale;
+
+public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
+
+    protected static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
+    private final NinchatEndlessRecyclerViewScrollListener scrollListener;
+    private final Callback callback;
+
+    public NinchatMessageViewHolder(View itemView, NinchatEndlessRecyclerViewScrollListener scrollListener, Callback callback) {
+        super(itemView);
+        this.scrollListener = scrollListener;
+        this.callback = callback;
+    }
+
+    private void setAvatar(final ImageView avatar, final NinchatMessage ninchatMessage, final boolean hideAvatar) {
+        String userAvatar = null;
+        final NinchatUser user = NinchatSessionManager.getInstance().getMember(ninchatMessage.getSenderId());
+        if (user != null) {
+            userAvatar = user.getAvatar();
+        }
+        if (TextUtils.isEmpty(userAvatar)) {
+            userAvatar = NinchatSessionManager.getInstance().getDefaultAvatar(ninchatMessage.isRemoteMessage());
+        }
+        if (!TextUtils.isEmpty(userAvatar)) {
+            GlideApp.with(itemView.getContext())
+                    .load(userAvatar)
+                    .circleCrop()
+                    .into(avatar);
+        }
+        final boolean showAvatars = NinchatSessionManager.getInstance().showAvatars(ninchatMessage.isRemoteMessage());
+        if (!showAvatars) {
+            avatar.setVisibility(View.GONE);
+        } else if (hideAvatar) {
+            avatar.setVisibility(showAvatars ? View.INVISIBLE : View.GONE);
+            return;
+        }
+    }
+
+    private void bindMessage(final @IdRes int wrapperId, final @IdRes int headerId, final @IdRes int senderId, final @IdRes int timestampId, final @IdRes int messageView, final @IdRes int imageId, final @IdRes int playIconId, final @IdRes int avatarId, final NinchatMessage ninchatMessage, final boolean isContinuedMessage, int firstMessageBackground, final @DrawableRes int repeatedMessageBackground) {
+        itemView.findViewById(wrapperId).setVisibility(View.VISIBLE);
+        itemView.findViewById(headerId).setVisibility(View.GONE);
+
+        final TextView sender = itemView.findViewById(senderId);
+        String senderNameOverride = NinchatSessionManager.getInstance().getName(senderId == R.id.ninchat_chat_message_agent_name);
+        sender.setText(senderNameOverride != null ? senderNameOverride : ninchatMessage.getSender());
+
+        final TextView timestamp = itemView.findViewById(timestampId);
+        timestamp.setText(TIMESTAMP_FORMATTER.format(ninchatMessage.getTimestamp()));
+        setAvatar(itemView.findViewById(avatarId), ninchatMessage, isContinuedMessage);
+        final TextView message = itemView.findViewById(messageView);
+        message.setVisibility(View.GONE);
+        final Spanned messageContent = ninchatMessage.getMessage();
+        final NinchatFile file = NinchatSessionManager.getInstance().getFile(ninchatMessage.getFileId());
+        final ImageView image = itemView.findViewById(imageId);
+        image.setVisibility(View.GONE);
+        final View playIcon = itemView.findViewById(playIconId);
+        playIcon.setVisibility(View.GONE);
+        GlideApp.with(image.getContext()).clear(image);
+        image.setBackground(null);
+        if (messageContent != null) {
+            message.setVisibility(View.VISIBLE);
+            message.setAutoLinkMask(Linkify.ALL);
+            message.setText(messageContent);
+        } else if (file.isDownloadableFile()) {
+            message.setVisibility(View.VISIBLE);
+            message.setText(file.getFileLink());
+            message.setMovementMethod(LinkMovementMethod.getInstance());
+        } else {
+            final int width = file.getWidth();
+            final int height = file.getHeight();
+            final float density = itemView.getResources().getDisplayMetrics().density;
+            image.getLayoutParams().width = (int) (width * density);
+            image.getLayoutParams().height = (int) (height * density);
+            image.setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
+            image.setVisibility(View.VISIBLE);
+            GlideApp.with(image.getContext())
+                    .load(file.getUrl())
+                    .placeholder(R.color.ninchat_colorPrimaryDark)
+                    .override(width, height)
+                    .into(image);
+            if (file.isVideo()) {
+                playIcon.setVisibility(View.VISIBLE);
+            }
+            image.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    v.getContext().startActivity(NinchatMediaActivity.getLaunchIntent(v.getContext(), ninchatMessage.getFileId()));
+                }
+            });
+        }
+        itemView.findViewById(messageView).setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
+        if (isContinuedMessage) {
+            itemView.findViewById(wrapperId).setPadding(0, 0, 0, 0);
+        } else {
+            itemView.findViewById(headerId).setVisibility(View.VISIBLE);
+        }
+    }
+
+    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+        if (data.getType() == NinchatMessage.Type.PADDING) {
+            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.VISIBLE);
+        } else if (data.getType() == NinchatMessage.Type.META) {
+            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+            final TextView start = itemView.findViewById(R.id.ninchat_chat_message_meta);
+            start.setText(data.getMessage());
+            start.setVisibility(View.VISIBLE);
+        } else if (data.getType() == NinchatMessage.Type.END) {
+            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+            final TextView end = itemView.findViewById(R.id.ninchat_chat_message_end_text);
+            end.setText(NinchatSessionManager.getInstance().getChatEnded());
+            final Button closeButton = itemView.findViewById(R.id.ninchat_chat_message_close);
+            closeButton.setText(NinchatSessionManager.getInstance().getCloseChat());
+            closeButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    callback.onClickListener();
+                }
+            });
+            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.VISIBLE);
+        } else if (data.getType().equals(NinchatMessage.Type.WRITING)) {
+            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
+            setAvatar(itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_message).setVisibility(View.GONE);
+
+            String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
+            final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
+            agentName.setText(agentNameOverride != null ? agentNameOverride : data.getSender());
+
+            itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper)
+                    .setBackgroundResource(isContinuedMessage ?
+                            R.drawable.ninchat_chat_bubble_left_repeated :
+                            R.drawable.ninchat_chat_bubble_left);
+            final ImageView image = itemView.findViewById(R.id.ninchat_chat_message_agent_writing);
+            image.setVisibility(View.VISIBLE);
+            GlideApp.with(image.getContext()).clear(image);
+            image.setBackgroundResource(R.drawable.ninchat_icon_chat_writing_indicator);
+            final AnimationDrawable animationDrawable = (AnimationDrawable) image.getBackground();
+            animationDrawable.start();
+            if (isContinuedMessage) {
+                itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
+            }
+        } else if (data.getType().equals(NinchatMessage.Type.MULTICHOICE)) {
+            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
+            setAvatar(itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+
+            String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
+            final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
+            agentName.setText(agentNameOverride != null ? agentNameOverride : data.getSender());
+
+            itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper)
+                    .setBackgroundResource(isContinuedMessage ?
+                            R.drawable.ninchat_chat_bubble_left_repeated :
+                            R.drawable.ninchat_chat_bubble_left);
+            final TextView message = itemView.findViewById(R.id.ninchat_chat_message_agent_message);
+            final Spanned messageText = data.getMessage();
+            message.setText(messageText);
+            message.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.VISIBLE);
+            final RecyclerView options = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_options);
+            options.setLayoutManager(messageText != null ? new LinearLayoutManager(itemView.getContext()) : new GridLayoutManager(itemView.getContext(), 2));
+            if (messageText == null) {
+                options.addItemDecoration(new RecyclerView.ItemDecoration() {
+                    @Override
+                    public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+                        outRect.top = 0;
+                        outRect.bottom = 0;
+                        if (parent.getChildLayoutPosition(view) % 2 == 0) {
+                            outRect.left = 0;
+                            outRect.right = 2;
+                        } else {
+                            outRect.left = 2;
+                            outRect.right = 0;
+                        }
+                    }
+                });
+            }
+            options.setAdapter(new NinchatMultiChoiceAdapter(data, this, messageText == null));
+            final Button sendButton = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_send);
+            sendButton.setText(NinchatSessionManager.getInstance().getSubmitButtonText());
+            sendButton.setOnClickListener(new View.OnClickListener() {
+                @Override
+                public void onClick(View v) {
+                    try {
+                        NinchatSessionManager.getInstance().sendUIAction(data.getMultiChoiceData());
+                    } catch (final JSONException e) {
+                        Log.e(NinchatMessageAdapter.class.getSimpleName(), "Error when sending multichoice answer!", e);
+                    }
+                }
+            });
+            sendButton.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper).getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+            if (isContinuedMessage) {
+                itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
+            }
+        } else if (data.isRemoteMessage()) {
+            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
+            bindMessage(R.id.ninchat_chat_message_agent,
+                    R.id.ninchat_chat_message_agent_title,
+                    R.id.ninchat_chat_message_agent_name,
+                    R.id.ninchat_chat_message_agent_timestamp,
+                    R.id.ninchat_chat_message_agent_message,
+                    R.id.ninchat_chat_message_agent_image,
+                    R.id.ninchat_chat_message_agent_video_play_image,
+                    R.id.ninchat_chat_message_agent_avatar,
+                    data, isContinuedMessage,
+                    R.drawable.ninchat_chat_bubble_left,
+                    R.drawable.ninchat_chat_bubble_left_repeated);
+        } else {
+            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+            bindMessage(R.id.ninchat_chat_message_user,
+                    R.id.ninchat_chat_message_user_title,
+                    R.id.ninchat_chat_message_user_name,
+                    R.id.ninchat_chat_message_user_timestamp,
+                    R.id.ninchat_chat_message_user_message,
+                    R.id.ninchat_chat_message_user_image,
+                    R.id.ninchat_chat_message_user_video_play_image,
+                    R.id.ninchat_chat_message_user_avatar,
+                    data, isContinuedMessage,
+                    R.drawable.ninchat_chat_bubble_right,
+                    R.drawable.ninchat_chat_bubble_right_repeated);
+        }
+        this.callback.onRequiredAnimationChange();
+    }
+
+    public void optionToggled(final NinchatMessage message, final int position) {
+        this.callback.onOptionToggled(message, getAdapterPosition());
+    }
+
+
+    public interface Callback {
+        void onClickListener();
+
+        void onOptionToggled(final NinchatMessage message, final int position);
+
+        void onRequiredAnimationChange();
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -38,7 +38,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
         } else if (data.getType() == NinchatMessage.Type.END) {
             endViewHolder.bind(callback);
         } else if (data.getType().equals(NinchatMessage.Type.WRITING)) {
-            writingViewHolder.bind(data, ninchatAvatar, this, isContinuedMessage);
+            writingViewHolder.bind(data, ninchatAvatar, isContinuedMessage);
         } else if (data.getType().equals(NinchatMessage.Type.MULTICHOICE)) {
             multipleChoiceViewHolder.bind(data, ninchatAvatar, this, isContinuedMessage);
         } else if (data.isRemoteMessage()) {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -293,7 +293,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
     }
 
     public void optionToggled(final NinchatMessage message, final int position) {
-        this.callback.onOptionToggled(message, getAdapterPosition());
+        this.callback.onOptionToggled(message, position);
     }
 
 

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -13,7 +13,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
     protected final NinchatMetaViewHolder metaViewHolder;
     protected final NinchatEndViewHolder endViewHolder;
     protected final NinchatWritingViewHolder writingViewHolder;
-    protected final NinchatMultipleChoiceViewHolder multipleChoiceViewHolder;
+    protected final NinchatOptionsViewHolder multipleChoiceViewHolder;
     protected final NinchatRemoteMessageViewHolder remoteMessageViewHolder;
     protected final NinchatGeneralViewHolder generalViewHolder;
     private final Callback callback;
@@ -26,7 +26,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
         metaViewHolder = new NinchatMetaViewHolder(itemView);
         endViewHolder = new NinchatEndViewHolder(itemView);
         writingViewHolder = new NinchatWritingViewHolder(itemView);
-        multipleChoiceViewHolder = new NinchatMultipleChoiceViewHolder(itemView);
+        multipleChoiceViewHolder = new NinchatOptionsViewHolder(itemView);
         remoteMessageViewHolder = new NinchatRemoteMessageViewHolder(itemView);
         generalViewHolder = new NinchatGeneralViewHolder(itemView);
     }
@@ -51,14 +51,14 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
     }
 
     public void onMultiChoiceOptionToggled(final NinchatMessage message, final int choiceIndex) {
-        this.callback.onMultiChoiceOptionToggled(message, choiceIndex, getAdapterPosition());
+        this.callback.onOptionsToggled(message, choiceIndex, getAdapterPosition());
     }
 
 
     public interface Callback {
         void onChatClosed();
 
-        void onMultiChoiceOptionToggled(final NinchatMessage message, final int choiceIndex, final int position);
+        void onOptionsToggled(final NinchatMessage message, final int choiceIndex, final int position);
 
         void onRequiredAnimationChange();
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -28,6 +28,7 @@ import com.ninchat.sdk.activities.NinchatChatActivity;
 import com.ninchat.sdk.activities.NinchatMediaActivity;
 import com.ninchat.sdk.adapters.NinchatMessageAdapter;
 import com.ninchat.sdk.adapters.NinchatMultiChoiceAdapter;
+import com.ninchat.sdk.helper.NinchatAvatar;
 import com.ninchat.sdk.helper.NinchatEndlessRecyclerViewScrollListener;
 import com.ninchat.sdk.models.NinchatFile;
 import com.ninchat.sdk.models.NinchatMessage;
@@ -41,37 +42,13 @@ import java.util.Locale;
 public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
 
     protected static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
-    private final NinchatEndlessRecyclerViewScrollListener scrollListener;
+    protected final NinchatAvatar ninchatAvatar;
     private final Callback callback;
 
-    public NinchatMessageViewHolder(View itemView, NinchatEndlessRecyclerViewScrollListener scrollListener, Callback callback) {
+    public NinchatMessageViewHolder(View itemView, Callback callback) {
         super(itemView);
-        this.scrollListener = scrollListener;
         this.callback = callback;
-    }
-
-    private void setAvatar(final ImageView avatar, final NinchatMessage ninchatMessage, final boolean hideAvatar) {
-        String userAvatar = null;
-        final NinchatUser user = NinchatSessionManager.getInstance().getMember(ninchatMessage.getSenderId());
-        if (user != null) {
-            userAvatar = user.getAvatar();
-        }
-        if (TextUtils.isEmpty(userAvatar)) {
-            userAvatar = NinchatSessionManager.getInstance().getDefaultAvatar(ninchatMessage.isRemoteMessage());
-        }
-        if (!TextUtils.isEmpty(userAvatar)) {
-            GlideApp.with(itemView.getContext())
-                    .load(userAvatar)
-                    .circleCrop()
-                    .into(avatar);
-        }
-        final boolean showAvatars = NinchatSessionManager.getInstance().showAvatars(ninchatMessage.isRemoteMessage());
-        if (!showAvatars) {
-            avatar.setVisibility(View.GONE);
-        } else if (hideAvatar) {
-            avatar.setVisibility(showAvatars ? View.INVISIBLE : View.GONE);
-            return;
-        }
+        ninchatAvatar = new NinchatAvatar();
     }
 
     private void bindMessage(final @IdRes int wrapperId, final @IdRes int headerId, final @IdRes int senderId, final @IdRes int timestampId, final @IdRes int messageView, final @IdRes int imageId, final @IdRes int playIconId, final @IdRes int avatarId, final NinchatMessage ninchatMessage, final boolean isContinuedMessage, int firstMessageBackground, final @DrawableRes int repeatedMessageBackground) {
@@ -84,7 +61,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
 
         final TextView timestamp = itemView.findViewById(timestampId);
         timestamp.setText(TIMESTAMP_FORMATTER.format(ninchatMessage.getTimestamp()));
-        setAvatar(itemView.findViewById(avatarId), ninchatMessage, isContinuedMessage);
+        ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(avatarId), ninchatMessage, isContinuedMessage);
         final TextView message = itemView.findViewById(messageView);
         message.setVisibility(View.GONE);
         final Spanned messageContent = ninchatMessage.getMessage();
@@ -174,7 +151,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
             itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
             itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
             itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
-            setAvatar(itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+            ninchatAvatar.setAvatar(itemView.getContext(),itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
             itemView.findViewById(R.id.ninchat_chat_message_agent_message).setVisibility(View.GONE);
 
             String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
@@ -203,7 +180,7 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
             itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
             itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
             itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
-            setAvatar(itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+            ninchatAvatar.setAvatar(itemView.getContext(),itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
 
             String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
             final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -49,15 +49,15 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
         this.callback.onRequiredAnimationChange();
     }
 
-    public void optionToggled(final NinchatMessage message, final int position) {
-        this.callback.onOptionToggled(message, position);
+    public void onMultiChoiceOptionToggled(final NinchatMessage message, final int position) {
+        this.callback.onMultiChoiceOptionToggled(message, position);
     }
 
 
     public interface Callback {
-        void onClickListener();
+        void onChatClosed();
 
-        void onOptionToggled(final NinchatMessage message, final int position);
+        void onMultiChoiceOptionToggled(final NinchatMessage message, final int position);
 
         void onRequiredAnimationChange();
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMessageViewHolder.java
@@ -1,34 +1,9 @@
 package com.ninchat.sdk.adapters.holders;
 
-import android.graphics.Rect;
-import android.graphics.drawable.AnimationDrawable;
-import android.support.annotation.DrawableRes;
-import android.support.annotation.IdRes;
-import android.support.annotation.NonNull;
-import android.support.v7.widget.GridLayoutManager;
-import android.support.v7.widget.LinearLayoutManager;
 import android.support.v7.widget.RecyclerView;
-import android.text.Spanned;
-import android.text.method.LinkMovementMethod;
-import android.text.util.Linkify;
-import android.util.Log;
 import android.view.View;
-import android.view.ViewGroup;
-import android.widget.Button;
-import android.widget.ImageView;
-import android.widget.TextView;
-
-import com.ninchat.sdk.GlideApp;
-import com.ninchat.sdk.NinchatSessionManager;
-import com.ninchat.sdk.R;
-import com.ninchat.sdk.activities.NinchatMediaActivity;
-import com.ninchat.sdk.adapters.NinchatMessageAdapter;
-import com.ninchat.sdk.adapters.NinchatMultiChoiceAdapter;
 import com.ninchat.sdk.helper.NinchatAvatar;
-import com.ninchat.sdk.models.NinchatFile;
 import com.ninchat.sdk.models.NinchatMessage;
-
-import org.json.JSONException;
 
 import java.text.SimpleDateFormat;
 import java.util.Locale;
@@ -37,240 +12,43 @@ public class NinchatMessageViewHolder extends RecyclerView.ViewHolder {
 
     protected static final SimpleDateFormat TIMESTAMP_FORMATTER = new SimpleDateFormat("HH:mm", new Locale("fi-FI"));
     protected final NinchatAvatar ninchatAvatar;
+    protected final NinchatPaddingViewHolder paddingViewHolder;
+    protected final NinchatMetaViewHolder metaViewHolder;
+    protected final NinchatEndViewHolder endViewHolder;
+    protected final NinchatWritingViewHolder writingViewHolder;
+    protected final NinchatMultipleChoiceViewHolder multipleChoiceViewHolder;
+    protected final NinchatRemoteMessageViewHolder remoteMessageViewHolder;
+    protected final NinchatGeneralViewHolder generalViewHolder;
     private final Callback callback;
 
     public NinchatMessageViewHolder(View itemView, Callback callback) {
         super(itemView);
         this.callback = callback;
         ninchatAvatar = new NinchatAvatar();
-    }
-
-    private void bindMessage(final @IdRes int wrapperId,
-                             final @IdRes int headerId,
-                             final @IdRes int senderId,
-                             final @IdRes int timestampId,
-                             final @IdRes int messageView,
-                             final @IdRes int imageId,
-                             final @IdRes int playIconId,
-                             final @IdRes int avatarId,
-                             final NinchatMessage ninchatMessage,
-                             final boolean isContinuedMessage,
-                             int firstMessageBackground,
-                             final @DrawableRes
-                             int repeatedMessageBackground) {
-        itemView.findViewById(wrapperId).setVisibility(View.VISIBLE);
-        itemView.findViewById(headerId).setVisibility(View.GONE);
-
-        final TextView sender = itemView.findViewById(senderId);
-        String senderNameOverride = NinchatSessionManager.getInstance().getName(senderId == R.id.ninchat_chat_message_agent_name);
-        sender.setText(senderNameOverride != null ? senderNameOverride : ninchatMessage.getSender());
-
-        final TextView timestamp = itemView.findViewById(timestampId);
-        timestamp.setText(TIMESTAMP_FORMATTER.format(ninchatMessage.getTimestamp()));
-        ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(avatarId), ninchatMessage, isContinuedMessage);
-        final TextView message = itemView.findViewById(messageView);
-        message.setVisibility(View.GONE);
-        final Spanned messageContent = ninchatMessage.getMessage();
-        final NinchatFile file = NinchatSessionManager.getInstance().getFile(ninchatMessage.getFileId());
-        final ImageView image = itemView.findViewById(imageId);
-        image.setVisibility(View.GONE);
-        final View playIcon = itemView.findViewById(playIconId);
-        playIcon.setVisibility(View.GONE);
-        GlideApp.with(image.getContext()).clear(image);
-        image.setBackground(null);
-        if (messageContent != null) {
-            message.setVisibility(View.VISIBLE);
-            message.setAutoLinkMask(Linkify.ALL);
-            message.setText(messageContent);
-        } else if (file.isDownloadableFile()) {
-            message.setVisibility(View.VISIBLE);
-            message.setText(file.getFileLink());
-            message.setMovementMethod(LinkMovementMethod.getInstance());
-        } else {
-            final int width = file.getWidth();
-            final int height = file.getHeight();
-            final float density = itemView.getResources().getDisplayMetrics().density;
-            image.getLayoutParams().width = (int) (width * density);
-            image.getLayoutParams().height = (int) (height * density);
-            image.setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
-            image.setVisibility(View.VISIBLE);
-            GlideApp.with(image.getContext())
-                    .load(file.getUrl())
-                    .placeholder(R.color.ninchat_colorPrimaryDark)
-                    .override(width, height)
-                    .into(image);
-            if (file.isVideo()) {
-                playIcon.setVisibility(View.VISIBLE);
-            }
-            image.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    v.getContext().startActivity(NinchatMediaActivity.getLaunchIntent(v.getContext(), ninchatMessage.getFileId()));
-                }
-            });
-        }
-        itemView.findViewById(messageView).setBackgroundResource(isContinuedMessage ? repeatedMessageBackground : firstMessageBackground);
-        if (isContinuedMessage) {
-            itemView.findViewById(wrapperId).setPadding(0, 0, 0, 0);
-        } else {
-            itemView.findViewById(headerId).setVisibility(View.VISIBLE);
-        }
+        paddingViewHolder = new NinchatPaddingViewHolder(itemView);
+        metaViewHolder = new NinchatMetaViewHolder(itemView);
+        endViewHolder = new NinchatEndViewHolder(itemView, callback);
+        writingViewHolder = new NinchatWritingViewHolder(itemView, ninchatAvatar);
+        multipleChoiceViewHolder = new NinchatMultipleChoiceViewHolder(itemView, ninchatAvatar, callback);
+        remoteMessageViewHolder = new NinchatRemoteMessageViewHolder(itemView, callback);
+        generalViewHolder = new NinchatGeneralViewHolder(itemView);
     }
 
     public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
         if (data.getType() == NinchatMessage.Type.PADDING) {
-            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.VISIBLE);
+            paddingViewHolder.bind(data, false);
         } else if (data.getType() == NinchatMessage.Type.META) {
-            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-            final TextView start = itemView.findViewById(R.id.ninchat_chat_message_meta);
-            start.setText(data.getMessage());
-            start.setVisibility(View.VISIBLE);
+            metaViewHolder.bind(data, false);
         } else if (data.getType() == NinchatMessage.Type.END) {
-            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-            final TextView end = itemView.findViewById(R.id.ninchat_chat_message_end_text);
-            end.setText(NinchatSessionManager.getInstance().getChatEnded());
-            final Button closeButton = itemView.findViewById(R.id.ninchat_chat_message_close);
-            closeButton.setText(NinchatSessionManager.getInstance().getCloseChat());
-            closeButton.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    callback.onClickListener();
-                }
-            });
-            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.VISIBLE);
+            endViewHolder.bind(data, false);
         } else if (data.getType().equals(NinchatMessage.Type.WRITING)) {
-            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
-            ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_message).setVisibility(View.GONE);
-
-            String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
-            final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
-            agentName.setText(agentNameOverride != null ? agentNameOverride : data.getSender());
-
-            itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper)
-                    .setBackgroundResource(isContinuedMessage ?
-                            R.drawable.ninchat_chat_bubble_left_repeated :
-                            R.drawable.ninchat_chat_bubble_left);
-            final ImageView image = itemView.findViewById(R.id.ninchat_chat_message_agent_writing);
-            image.setVisibility(View.VISIBLE);
-            GlideApp.with(image.getContext()).clear(image);
-            image.setBackgroundResource(R.drawable.ninchat_icon_chat_writing_indicator);
-            final AnimationDrawable animationDrawable = (AnimationDrawable) image.getBackground();
-            animationDrawable.start();
-            if (isContinuedMessage) {
-                itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
-            }
+            writingViewHolder.bind(data, isContinuedMessage);
         } else if (data.getType().equals(NinchatMessage.Type.MULTICHOICE)) {
-            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
-            ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
-
-            String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
-            final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
-            agentName.setText(agentNameOverride != null ? agentNameOverride : data.getSender());
-
-            itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper)
-                    .setBackgroundResource(isContinuedMessage ?
-                            R.drawable.ninchat_chat_bubble_left_repeated :
-                            R.drawable.ninchat_chat_bubble_left);
-            final TextView message = itemView.findViewById(R.id.ninchat_chat_message_agent_message);
-            final Spanned messageText = data.getMessage();
-            message.setText(messageText);
-            message.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.VISIBLE);
-            final RecyclerView options = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_options);
-            options.setLayoutManager(messageText != null ? new LinearLayoutManager(itemView.getContext()) : new GridLayoutManager(itemView.getContext(), 2));
-            if (messageText == null) {
-                options.addItemDecoration(new RecyclerView.ItemDecoration() {
-                    @Override
-                    public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
-                        outRect.top = 0;
-                        outRect.bottom = 0;
-                        if (parent.getChildLayoutPosition(view) % 2 == 0) {
-                            outRect.left = 0;
-                            outRect.right = 2;
-                        } else {
-                            outRect.left = 2;
-                            outRect.right = 0;
-                        }
-                    }
-                });
-            }
-            options.setAdapter(new NinchatMultiChoiceAdapter(data, this, messageText == null));
-            final Button sendButton = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_send);
-            sendButton.setText(NinchatSessionManager.getInstance().getSubmitButtonText());
-            sendButton.setOnClickListener(new View.OnClickListener() {
-                @Override
-                public void onClick(View v) {
-                    try {
-                        NinchatSessionManager.getInstance().sendUIAction(data.getMultiChoiceData());
-                    } catch (final JSONException e) {
-                        Log.e(NinchatMessageAdapter.class.getSimpleName(), "Error when sending multichoice answer!", e);
-                    }
-                }
-            });
-            sendButton.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper).getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
-            if (isContinuedMessage) {
-                itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
-            }
+            multipleChoiceViewHolder.bind(data, isContinuedMessage);
         } else if (data.isRemoteMessage()) {
-            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
-            bindMessage(R.id.ninchat_chat_message_agent,
-                    R.id.ninchat_chat_message_agent_title,
-                    R.id.ninchat_chat_message_agent_name,
-                    R.id.ninchat_chat_message_agent_timestamp,
-                    R.id.ninchat_chat_message_agent_message,
-                    R.id.ninchat_chat_message_agent_image,
-                    R.id.ninchat_chat_message_agent_video_play_image,
-                    R.id.ninchat_chat_message_agent_avatar,
-                    data, isContinuedMessage,
-                    R.drawable.ninchat_chat_bubble_left,
-                    R.drawable.ninchat_chat_bubble_left_repeated);
+            remoteMessageViewHolder.bind(data, isContinuedMessage);
         } else {
-            itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
-            itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
-            bindMessage(R.id.ninchat_chat_message_user,
-                    R.id.ninchat_chat_message_user_title,
-                    R.id.ninchat_chat_message_user_name,
-                    R.id.ninchat_chat_message_user_timestamp,
-                    R.id.ninchat_chat_message_user_message,
-                    R.id.ninchat_chat_message_user_image,
-                    R.id.ninchat_chat_message_user_video_play_image,
-                    R.id.ninchat_chat_message_user_avatar,
-                    data, isContinuedMessage,
-                    R.drawable.ninchat_chat_bubble_right,
-                    R.drawable.ninchat_chat_bubble_right_repeated);
+            generalViewHolder.bind(data, isContinuedMessage);
         }
         this.callback.onRequiredAnimationChange();
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMetaViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMetaViewHolder.java
@@ -16,7 +16,7 @@ public class NinchatMetaViewHolder extends NinchatBaseViewHolder {
         super(itemView);
     }
 
-    public void bind(@NotNull final NinchatMessage data, final boolean isContinuedMessage) {
+    public void bind(@NotNull final NinchatMessage data) {
         itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMetaViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMetaViewHolder.java
@@ -1,0 +1,33 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.support.annotation.NonNull;
+import android.text.Spannable;
+import android.text.Spanned;
+import android.view.View;
+import android.widget.TextView;
+
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.models.NinchatMessage;
+
+import org.jetbrains.annotations.NotNull;
+
+public class NinchatMetaViewHolder extends NinchatBaseViewHolder {
+    public NinchatMetaViewHolder(@NonNull View itemView) {
+        super(itemView);
+    }
+
+    public void bind(@NotNull final NinchatMessage data, final boolean isContinuedMessage) {
+        itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+        setVisible(data.getMessage());
+    }
+
+    protected void setVisible(final Spanned message) {
+        final TextView start = itemView.findViewById(R.id.ninchat_chat_message_meta);
+        start.setText(message);
+        start.setVisibility(View.VISIBLE);
+    }
+
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultiChoiceViewholder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultiChoiceViewholder.java
@@ -1,0 +1,46 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.TextView;
+
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.models.NinchatMessage;
+import com.ninchat.sdk.models.NinchatOption;
+
+import java.util.List;
+
+public class NinchatMultiChoiceViewholder extends RecyclerView.ViewHolder {
+    protected final Callback callback;
+
+    public NinchatMultiChoiceViewholder(@NonNull View itemView, final Callback callback) {
+        super(itemView);
+        this.callback = callback;
+    }
+
+    public void bind(final NinchatMessage message, final int position, final boolean sendAction) {
+        final TextView button = (TextView) itemView;
+        final List<NinchatOption> options = message.getOptions();
+        final NinchatOption option = options.get(position);
+        button.setText(option.getLabel());
+        button.setOnClickListener(v -> {
+            this.callback.onClickListener(message, position);
+            if (sendAction) {
+                try {
+                    option.toggle();
+                    NinchatSessionManager.getInstance().sendUIAction(option.toJSON());
+                    option.toggle();
+                } catch (final Exception e) {
+                    // Ignore
+                }
+            } else {
+                this.callback.onClickListener(message, position);
+            }
+        });
+    }
+
+    public interface Callback {
+        void onClickListener(final NinchatMessage message, final int position);
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultiChoiceViewholder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultiChoiceViewholder.java
@@ -35,7 +35,7 @@ public class NinchatMultiChoiceViewholder extends RecyclerView.ViewHolder {
                     option.toggle();
                 }
             } else {
-                callback.onClickListener(message, position);
+                callback.onMultiChoiceOptionToggled(message, position);
             }
         });
     }
@@ -61,6 +61,6 @@ public class NinchatMultiChoiceViewholder extends RecyclerView.ViewHolder {
     }
 
     public interface Callback {
-        void onClickListener(final NinchatMessage message, final int position);
+        void onMultiChoiceOptionToggled(final NinchatMessage message, final int position);
     }
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultiChoiceViewholder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultiChoiceViewholder.java
@@ -19,10 +19,10 @@ public class NinchatMultiChoiceViewholder extends RecyclerView.ViewHolder {
         super(itemView);
     }
 
-    public void bind(final NinchatMessage message, final int position, final boolean sendAction, final Callback callback) {
+    public void bind(final NinchatMessage message, final boolean sendAction, final Callback callback) {
         final TextView button = this.getButtonItem();
         final List<NinchatOption> options = getNinchatOptions(message);
-        final NinchatOption option = getNinchatOption(options, position);
+        final NinchatOption option = getNinchatOption(options, getAdapterPosition());
         button.setText(option.getLabel());
         button.setOnClickListener(v -> {
             if (sendAction) {
@@ -35,7 +35,7 @@ public class NinchatMultiChoiceViewholder extends RecyclerView.ViewHolder {
                     option.toggle();
                 }
             } else {
-                callback.onMultiChoiceOptionToggled(message, position);
+                callback.onMultiChoiceOptionToggled(message, getAdapterPosition());
             }
         });
     }
@@ -61,6 +61,6 @@ public class NinchatMultiChoiceViewholder extends RecyclerView.ViewHolder {
     }
 
     public interface Callback {
-        void onMultiChoiceOptionToggled(final NinchatMessage message, final int position);
+        void onMultiChoiceOptionToggled(final NinchatMessage message, final int choiceIndex);
     }
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultipleChoiceViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultipleChoiceViewHolder.java
@@ -81,14 +81,11 @@ public class NinchatMultipleChoiceViewHolder extends NinchatBaseViewHolder {
         options.setAdapter(new NinchatMultiChoiceAdapter(data, messageViewHolder, messageText == null));
         final Button sendButton = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_send);
         sendButton.setText(NinchatSessionManager.getInstance().getSubmitButtonText());
-        sendButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                try {
-                    NinchatSessionManager.getInstance().sendUIAction(data.getMultiChoiceData());
-                } catch (final JSONException e) {
-                    Log.e(NinchatMessageAdapter.class.getSimpleName(), "Error when sending multichoice answer!", e);
-                }
+        sendButton.setOnClickListener(v -> {
+            try {
+                NinchatSessionManager.getInstance().sendUIAction(data.getMultiChoiceData());
+            } catch (final JSONException e) {
+                Log.e(NinchatMessageAdapter.class.getSimpleName(), "Error when sending multichoice answer!", e);
             }
         });
         sendButton.setVisibility(messageText != null ? View.VISIBLE : View.GONE);

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultipleChoiceViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultipleChoiceViewHolder.java
@@ -25,6 +25,7 @@ import com.ninchat.sdk.models.NinchatMessage;
 import org.json.JSONException;
 
 public class NinchatMultipleChoiceViewHolder extends NinchatBaseViewHolder {
+    private final String TAG = NinchatMultipleChoiceViewHolder.class.getSimpleName();
 
     public NinchatMultipleChoiceViewHolder(@NonNull View itemView) {
         super(itemView);

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultipleChoiceViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultipleChoiceViewHolder.java
@@ -1,40 +1,51 @@
 package com.ninchat.sdk.adapters.holders;
 
+import android.graphics.Rect;
 import android.graphics.drawable.AnimationDrawable;
 import android.support.annotation.NonNull;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.text.Spanned;
+import android.util.Log;
 import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
 import android.widget.ImageView;
 import android.widget.TextView;
 
 import com.ninchat.sdk.GlideApp;
 import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
+import com.ninchat.sdk.adapters.NinchatMessageAdapter;
+import com.ninchat.sdk.adapters.NinchatMultiChoiceAdapter;
 import com.ninchat.sdk.helper.NinchatAvatar;
 import com.ninchat.sdk.models.NinchatMessage;
 
-public class NinchatMultipleChoiceViewHolder extends NinchatBaseViewHolder {
-    private final NinchatMessageViewHolder.Callback callback;
-    private final NinchatAvatar ninchatAvatar;
+import org.json.JSONException;
 
-    public NinchatMultipleChoiceViewHolder(@NonNull View itemView,
-                                           NinchatAvatar ninchatAvatar,
-                                           NinchatMessageViewHolder.Callback callback) {
+public class NinchatMultipleChoiceViewHolder extends NinchatBaseViewHolder {
+
+    public NinchatMultipleChoiceViewHolder(@NonNull View itemView) {
         super(itemView);
-        this.callback = callback;
-        this.ninchatAvatar = ninchatAvatar;
     }
 
-    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+    public void bind(final NinchatMessage data,
+                     final NinchatAvatar ninchatAvatar,
+                     final NinchatMessageViewHolder messageViewHolder,
+                     final boolean isContinuedMessage) {
         itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
         itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
-        itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
-        ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
-        itemView.findViewById(R.id.ninchat_chat_message_agent_message).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
+        ninchatAvatar.setAvatar(itemView.getContext(),
+                itemView.findViewById(R.id.ninchat_chat_message_agent_avatar),
+                data,
+                isContinuedMessage);
 
         String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
         final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
@@ -44,12 +55,44 @@ public class NinchatMultipleChoiceViewHolder extends NinchatBaseViewHolder {
                 .setBackgroundResource(isContinuedMessage ?
                         R.drawable.ninchat_chat_bubble_left_repeated :
                         R.drawable.ninchat_chat_bubble_left);
-        final ImageView image = itemView.findViewById(R.id.ninchat_chat_message_agent_writing);
-        image.setVisibility(View.VISIBLE);
-        GlideApp.with(image.getContext()).clear(image);
-        image.setBackgroundResource(R.drawable.ninchat_icon_chat_writing_indicator);
-        final AnimationDrawable animationDrawable = (AnimationDrawable) image.getBackground();
-        animationDrawable.start();
+        final TextView message = itemView.findViewById(R.id.ninchat_chat_message_agent_message);
+        final Spanned messageText = data.getMessage();
+        message.setText(messageText);
+        message.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.VISIBLE);
+        final RecyclerView options = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_options);
+        options.setLayoutManager(messageText != null ? new LinearLayoutManager(itemView.getContext()) : new GridLayoutManager(itemView.getContext(), 2));
+        if (messageText == null) {
+            options.addItemDecoration(new RecyclerView.ItemDecoration() {
+                @Override
+                public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+                    outRect.top = 0;
+                    outRect.bottom = 0;
+                    if (parent.getChildLayoutPosition(view) % 2 == 0) {
+                        outRect.left = 0;
+                        outRect.right = 2;
+                    } else {
+                        outRect.left = 2;
+                        outRect.right = 0;
+                    }
+                }
+            });
+        }
+        options.setAdapter(new NinchatMultiChoiceAdapter(data, messageViewHolder, messageText == null));
+        final Button sendButton = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_send);
+        sendButton.setText(NinchatSessionManager.getInstance().getSubmitButtonText());
+        sendButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                try {
+                    NinchatSessionManager.getInstance().sendUIAction(data.getMultiChoiceData());
+                } catch (final JSONException e) {
+                    Log.e(NinchatMessageAdapter.class.getSimpleName(), "Error when sending multichoice answer!", e);
+                }
+            }
+        });
+        sendButton.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper).getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
         if (isContinuedMessage) {
             itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
         }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultipleChoiceViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatMultipleChoiceViewHolder.java
@@ -1,0 +1,57 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.graphics.drawable.AnimationDrawable;
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.ninchat.sdk.GlideApp;
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.helper.NinchatAvatar;
+import com.ninchat.sdk.models.NinchatMessage;
+
+public class NinchatMultipleChoiceViewHolder extends NinchatBaseViewHolder {
+    private final NinchatMessageViewHolder.Callback callback;
+    private final NinchatAvatar ninchatAvatar;
+
+    public NinchatMultipleChoiceViewHolder(@NonNull View itemView,
+                                           NinchatAvatar ninchatAvatar,
+                                           NinchatMessageViewHolder.Callback callback) {
+        super(itemView);
+        this.callback = callback;
+        this.ninchatAvatar = ninchatAvatar;
+    }
+
+    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+        itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
+        ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_message).setVisibility(View.GONE);
+
+        String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
+        final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
+        agentName.setText(agentNameOverride != null ? agentNameOverride : data.getSender());
+
+        itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper)
+                .setBackgroundResource(isContinuedMessage ?
+                        R.drawable.ninchat_chat_bubble_left_repeated :
+                        R.drawable.ninchat_chat_bubble_left);
+        final ImageView image = itemView.findViewById(R.id.ninchat_chat_message_agent_writing);
+        image.setVisibility(View.VISIBLE);
+        GlideApp.with(image.getContext()).clear(image);
+        image.setBackgroundResource(R.drawable.ninchat_icon_chat_writing_indicator);
+        final AnimationDrawable animationDrawable = (AnimationDrawable) image.getBackground();
+        animationDrawable.start();
+        if (isContinuedMessage) {
+            itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
+        }
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatOptionsViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatOptionsViewHolder.java
@@ -1,7 +1,6 @@
 package com.ninchat.sdk.adapters.holders;
 
 import android.graphics.Rect;
-import android.graphics.drawable.AnimationDrawable;
 import android.support.annotation.NonNull;
 import android.support.v7.widget.GridLayoutManager;
 import android.support.v7.widget.LinearLayoutManager;
@@ -11,10 +10,8 @@ import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
-import android.widget.ImageView;
 import android.widget.TextView;
 
-import com.ninchat.sdk.GlideApp;
 import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
 import com.ninchat.sdk.adapters.NinchatMessageAdapter;
@@ -24,10 +21,10 @@ import com.ninchat.sdk.models.NinchatMessage;
 
 import org.json.JSONException;
 
-public class NinchatMultipleChoiceViewHolder extends NinchatBaseViewHolder {
-    private final String TAG = NinchatMultipleChoiceViewHolder.class.getSimpleName();
+public class NinchatOptionsViewHolder extends NinchatBaseViewHolder {
+    private final String TAG = NinchatOptionsViewHolder.class.getSimpleName();
 
-    public NinchatMultipleChoiceViewHolder(@NonNull View itemView) {
+    public NinchatOptionsViewHolder(@NonNull View itemView) {
         super(itemView);
     }
 

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatPaddingViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatPaddingViewHolder.java
@@ -1,0 +1,21 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.models.NinchatMessage;
+
+public class NinchatPaddingViewHolder extends NinchatBaseViewHolder {
+    public NinchatPaddingViewHolder(@NonNull View itemView) {
+        super(itemView);
+    }
+
+    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+        itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.VISIBLE);
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatPaddingViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatPaddingViewHolder.java
@@ -11,7 +11,7 @@ public class NinchatPaddingViewHolder extends NinchatBaseViewHolder {
         super(itemView);
     }
 
-    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+    public void bind() {
         itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolder.java
@@ -26,7 +26,7 @@ public class NinchatQueueViewHolder extends RecyclerView.ViewHolder {
             button.setAlpha(1f);
             button.setText(this.getText(queue));
             button.setOnClickListener(v -> {
-                callback.onClickListener(queue.getId());
+                callback.onQueueSelected(queue.getId());
             });
         }
     }
@@ -49,6 +49,6 @@ public class NinchatQueueViewHolder extends RecyclerView.ViewHolder {
     }
 
     public interface Callback {
-        void onClickListener(String queueId);
+        void onQueueSelected(String queueId);
     }
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolder.java
@@ -1,0 +1,41 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.support.v7.widget.RecyclerView;
+import android.view.View;
+import android.widget.Button;
+
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.models.NinchatQueue;
+
+public class NinchatQueueViewHolder extends RecyclerView.ViewHolder {
+    public NinchatQueueViewHolder(final View itemView) {
+        super(itemView);
+    }
+
+    public void bind(final NinchatQueue queue, final Callback callback) {
+        final Button button = itemView.findViewById(R.id.queue_name);
+
+        // If queue is closed, disable button and set alpha for look & feel
+        if (queue.isClosed()) {
+            button.setEnabled(false);
+            button.setAlpha(0.5f);
+            button.setText(NinchatSessionManager
+                    .getInstance()
+                    .getQueueName(queue.getName(), queue.isClosed()));
+        } else {
+            button.setAlpha(1f);
+            button.setText(NinchatSessionManager
+                    .getInstance()
+                    .getQueueName(queue.getName()));
+            button.setOnClickListener(v -> {
+                callback.onClickListener(queue.getId());
+            });
+        }
+    }
+
+
+    public interface Callback {
+        void onClickListener(String queueId);
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolder.java
@@ -14,26 +14,37 @@ public class NinchatQueueViewHolder extends RecyclerView.ViewHolder {
     }
 
     public void bind(final NinchatQueue queue, final Callback callback) {
-        final Button button = itemView.findViewById(R.id.queue_name);
-
+        final Button button = this.getButtonItem();
         // If queue is closed, disable button and set alpha for look & feel
         if (queue.isClosed()) {
             button.setEnabled(false);
             button.setAlpha(0.5f);
-            button.setText(NinchatSessionManager
-                    .getInstance()
-                    .getQueueName(queue.getName(), queue.isClosed()));
+            button.setText(this.getText(queue));
         } else {
             button.setAlpha(1f);
-            button.setText(NinchatSessionManager
-                    .getInstance()
-                    .getQueueName(queue.getName()));
+            button.setText(this.getText(queue));
             button.setOnClickListener(v -> {
                 callback.onClickListener(queue.getId());
             });
         }
     }
 
+    public String getText(final NinchatQueue queue) {
+        if (queue == null) return null;
+        if (queue.isClosed()) {
+            NinchatSessionManager
+                    .getInstance()
+                    .getQueueName(queue.getName(), queue.isClosed());
+        }
+        return NinchatSessionManager
+                .getInstance()
+                .getQueueName(queue.getName());
+
+    }
+
+    public Button getButtonItem() {
+        return itemView.findViewById(R.id.queue_name);
+    }
 
     public interface Callback {
         void onClickListener(String queueId);

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolder.java
@@ -8,12 +8,14 @@ import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
 import com.ninchat.sdk.models.NinchatQueue;
 
+import org.jetbrains.annotations.NotNull;
+
 public class NinchatQueueViewHolder extends RecyclerView.ViewHolder {
     public NinchatQueueViewHolder(final View itemView) {
         super(itemView);
     }
 
-    public void bind(final NinchatQueue queue, final Callback callback) {
+    public void bind(@NotNull final NinchatQueue queue, final Callback callback) {
         final Button button = this.getButtonItem();
         // If queue is closed, disable button and set alpha for look & feel
         if (queue.isClosed()) {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatRemoteMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatRemoteMessageViewHolder.java
@@ -1,0 +1,41 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.support.annotation.NonNull;
+import android.view.View;
+import android.widget.Button;
+import android.widget.TextView;
+
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.models.NinchatMessage;
+
+public class NinchatRemoteMessageViewHolder extends NinchatBaseViewHolder {
+    private final NinchatMessageViewHolder.Callback callback;
+
+    public NinchatRemoteMessageViewHolder(@NonNull View itemView, NinchatMessageViewHolder.Callback callback) {
+        super(itemView);
+        this.callback = callback;
+    }
+
+    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+        itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
+
+        /*bindMessage(R.id.ninchat_chat_message_agent,
+                R.id.ninchat_chat_message_agent_title,
+                R.id.ninchat_chat_message_agent_name,
+                R.id.ninchat_chat_message_agent_timestamp,
+                R.id.ninchat_chat_message_agent_message,
+                R.id.ninchat_chat_message_agent_image,
+                R.id.ninchat_chat_message_agent_video_play_image,
+                R.id.ninchat_chat_message_agent_avatar,
+                data, isContinuedMessage,
+                R.drawable.ninchat_chat_bubble_left,
+                R.drawable.ninchat_chat_bubble_left_repeated);*/
+
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatRemoteMessageViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatRemoteMessageViewHolder.java
@@ -7,17 +7,18 @@ import android.widget.TextView;
 
 import com.ninchat.sdk.NinchatSessionManager;
 import com.ninchat.sdk.R;
+import com.ninchat.sdk.helper.NinchatAvatar;
 import com.ninchat.sdk.models.NinchatMessage;
 
 public class NinchatRemoteMessageViewHolder extends NinchatBaseViewHolder {
-    private final NinchatMessageViewHolder.Callback callback;
 
-    public NinchatRemoteMessageViewHolder(@NonNull View itemView, NinchatMessageViewHolder.Callback callback) {
+    public NinchatRemoteMessageViewHolder(@NonNull View itemView) {
         super(itemView);
-        this.callback = callback;
     }
 
-    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+    public void bind(final NinchatMessage data,
+                     final NinchatAvatar ninchatAvatar,
+                     final boolean isContinuedMessage) {
         itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
@@ -25,7 +26,7 @@ public class NinchatRemoteMessageViewHolder extends NinchatBaseViewHolder {
         itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
 
-        /*bindMessage(R.id.ninchat_chat_message_agent,
+        bindMessage(R.id.ninchat_chat_message_agent,
                 R.id.ninchat_chat_message_agent_title,
                 R.id.ninchat_chat_message_agent_name,
                 R.id.ninchat_chat_message_agent_timestamp,
@@ -35,7 +36,8 @@ public class NinchatRemoteMessageViewHolder extends NinchatBaseViewHolder {
                 R.id.ninchat_chat_message_agent_avatar,
                 data, isContinuedMessage,
                 R.drawable.ninchat_chat_bubble_left,
-                R.drawable.ninchat_chat_bubble_left_repeated);*/
+                R.drawable.ninchat_chat_bubble_left_repeated,
+                ninchatAvatar);
 
     }
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatWritingViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatWritingViewHolder.java
@@ -32,7 +32,6 @@ public class NinchatWritingViewHolder extends NinchatBaseViewHolder {
 
     public void bind(final NinchatMessage data,
                      final NinchatAvatar ninchatAvatar,
-                     final NinchatMessageViewHolder messageViewHolder,
                      final boolean isContinuedMessage) {
         itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
@@ -40,9 +39,10 @@ public class NinchatWritingViewHolder extends NinchatBaseViewHolder {
         itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
         itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
-        itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
         ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_message).setVisibility(View.GONE);
 
         String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
         final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
@@ -52,44 +52,12 @@ public class NinchatWritingViewHolder extends NinchatBaseViewHolder {
                 .setBackgroundResource(isContinuedMessage ?
                         R.drawable.ninchat_chat_bubble_left_repeated :
                         R.drawable.ninchat_chat_bubble_left);
-        final TextView message = itemView.findViewById(R.id.ninchat_chat_message_agent_message);
-        final Spanned messageText = data.getMessage();
-        message.setText(messageText);
-        message.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
-        itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.VISIBLE);
-        final RecyclerView options = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_options);
-        options.setLayoutManager(messageText != null ? new LinearLayoutManager(itemView.getContext()) : new GridLayoutManager(itemView.getContext(), 2));
-        if (messageText == null) {
-            options.addItemDecoration(new RecyclerView.ItemDecoration() {
-                @Override
-                public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
-                    outRect.top = 0;
-                    outRect.bottom = 0;
-                    if (parent.getChildLayoutPosition(view) % 2 == 0) {
-                        outRect.left = 0;
-                        outRect.right = 2;
-                    } else {
-                        outRect.left = 2;
-                        outRect.right = 0;
-                    }
-                }
-            });
-        }
-        options.setAdapter(new NinchatMultiChoiceAdapter(data, messageViewHolder, messageText == null));
-        final Button sendButton = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_send);
-        sendButton.setText(NinchatSessionManager.getInstance().getSubmitButtonText());
-        sendButton.setOnClickListener(new View.OnClickListener() {
-            @Override
-            public void onClick(View v) {
-                try {
-                    NinchatSessionManager.getInstance().sendUIAction(data.getMultiChoiceData());
-                } catch (final JSONException e) {
-                    Log.e(NinchatMessageAdapter.class.getSimpleName(), "Error when sending multichoice answer!", e);
-                }
-            }
-        });
-        sendButton.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
-        itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper).getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+        final ImageView image = itemView.findViewById(R.id.ninchat_chat_message_agent_writing);
+        image.setVisibility(View.VISIBLE);
+        GlideApp.with(image.getContext()).clear(image);
+        image.setBackgroundResource(R.drawable.ninchat_icon_chat_writing_indicator);
+        final AnimationDrawable animationDrawable = (AnimationDrawable) image.getBackground();
+        animationDrawable.start();
         if (isContinuedMessage) {
             itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
         }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatWritingViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatWritingViewHolder.java
@@ -28,7 +28,7 @@ public class NinchatWritingViewHolder extends NinchatBaseViewHolder {
     private final NinchatAvatar ninchatAvatar;
 
     public NinchatWritingViewHolder(@NonNull View itemView,
-                                    NinchatAvatar ninchatAvatar) {
+                                    final NinchatAvatar ninchatAvatar) {
         super(itemView);
         this.ninchatAvatar = ninchatAvatar;
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatWritingViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatWritingViewHolder.java
@@ -25,15 +25,15 @@ import com.ninchat.sdk.models.NinchatMessage;
 import org.json.JSONException;
 
 public class NinchatWritingViewHolder extends NinchatBaseViewHolder {
-    private final NinchatAvatar ninchatAvatar;
 
-    public NinchatWritingViewHolder(@NonNull View itemView,
-                                    final NinchatAvatar ninchatAvatar) {
+    public NinchatWritingViewHolder(@NonNull View itemView) {
         super(itemView);
-        this.ninchatAvatar = ninchatAvatar;
     }
 
-    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+    public void bind(final NinchatMessage data,
+                     final NinchatAvatar ninchatAvatar,
+                     final NinchatMessageViewHolder messageViewHolder,
+                     final boolean isContinuedMessage) {
         itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
         itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
@@ -75,7 +75,7 @@ public class NinchatWritingViewHolder extends NinchatBaseViewHolder {
                 }
             });
         }
-        // options.setAdapter(new NinchatMultiChoiceAdapter(data, this, messageText == null));
+        options.setAdapter(new NinchatMultiChoiceAdapter(data, messageViewHolder, messageText == null));
         final Button sendButton = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_send);
         sendButton.setText(NinchatSessionManager.getInstance().getSubmitButtonText());
         sendButton.setOnClickListener(new View.OnClickListener() {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatWritingViewHolder.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/holders/NinchatWritingViewHolder.java
@@ -1,0 +1,97 @@
+package com.ninchat.sdk.adapters.holders;
+
+import android.graphics.Rect;
+import android.graphics.drawable.AnimationDrawable;
+import android.support.annotation.NonNull;
+import android.support.v7.widget.GridLayoutManager;
+import android.support.v7.widget.LinearLayoutManager;
+import android.support.v7.widget.RecyclerView;
+import android.text.Spanned;
+import android.util.Log;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.Button;
+import android.widget.ImageView;
+import android.widget.TextView;
+
+import com.ninchat.sdk.GlideApp;
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.R;
+import com.ninchat.sdk.adapters.NinchatMessageAdapter;
+import com.ninchat.sdk.adapters.NinchatMultiChoiceAdapter;
+import com.ninchat.sdk.helper.NinchatAvatar;
+import com.ninchat.sdk.models.NinchatMessage;
+
+import org.json.JSONException;
+
+public class NinchatWritingViewHolder extends NinchatBaseViewHolder {
+    private final NinchatAvatar ninchatAvatar;
+
+    public NinchatWritingViewHolder(@NonNull View itemView,
+                                    NinchatAvatar ninchatAvatar) {
+        super(itemView);
+        this.ninchatAvatar = ninchatAvatar;
+    }
+
+    public void bind(final NinchatMessage data, final boolean isContinuedMessage) {
+        itemView.findViewById(R.id.ninchat_chat_message_meta).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_user).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_end).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_padding).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent).setVisibility(View.VISIBLE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_image).setVisibility(View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_title).setVisibility(isContinuedMessage ? View.GONE : View.VISIBLE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_writing).setVisibility(View.GONE);
+        ninchatAvatar.setAvatar(itemView.getContext(), itemView.findViewById(R.id.ninchat_chat_message_agent_avatar), data, isContinuedMessage);
+
+        String agentNameOverride = NinchatSessionManager.getInstance().getName(true);
+        final TextView agentName = itemView.findViewById(R.id.ninchat_chat_message_agent_name);
+        agentName.setText(agentNameOverride != null ? agentNameOverride : data.getSender());
+
+        itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper)
+                .setBackgroundResource(isContinuedMessage ?
+                        R.drawable.ninchat_chat_bubble_left_repeated :
+                        R.drawable.ninchat_chat_bubble_left);
+        final TextView message = itemView.findViewById(R.id.ninchat_chat_message_agent_message);
+        final Spanned messageText = data.getMessage();
+        message.setText(messageText);
+        message.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice).setVisibility(View.VISIBLE);
+        final RecyclerView options = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_options);
+        options.setLayoutManager(messageText != null ? new LinearLayoutManager(itemView.getContext()) : new GridLayoutManager(itemView.getContext(), 2));
+        if (messageText == null) {
+            options.addItemDecoration(new RecyclerView.ItemDecoration() {
+                @Override
+                public void getItemOffsets(@NonNull Rect outRect, @NonNull View view, @NonNull RecyclerView parent, @NonNull RecyclerView.State state) {
+                    outRect.top = 0;
+                    outRect.bottom = 0;
+                    if (parent.getChildLayoutPosition(view) % 2 == 0) {
+                        outRect.left = 0;
+                        outRect.right = 2;
+                    } else {
+                        outRect.left = 2;
+                        outRect.right = 0;
+                    }
+                }
+            });
+        }
+        // options.setAdapter(new NinchatMultiChoiceAdapter(data, this, messageText == null));
+        final Button sendButton = itemView.findViewById(R.id.ninchat_chat_message_agent_multichoice_send);
+        sendButton.setText(NinchatSessionManager.getInstance().getSubmitButtonText());
+        sendButton.setOnClickListener(new View.OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                try {
+                    NinchatSessionManager.getInstance().sendUIAction(data.getMultiChoiceData());
+                } catch (final JSONException e) {
+                    Log.e(NinchatMessageAdapter.class.getSimpleName(), "Error when sending multichoice answer!", e);
+                }
+            }
+        });
+        sendButton.setVisibility(messageText != null ? View.VISIBLE : View.GONE);
+        itemView.findViewById(R.id.ninchat_chat_message_agent_wrapper).getLayoutParams().width = ViewGroup.LayoutParams.MATCH_PARENT;
+        if (isContinuedMessage) {
+            itemView.findViewById(R.id.ninchat_chat_message_agent).setPadding(0, 0, 0, 0);
+        }
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/helper/EndlessRecyclerViewScrollListener.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/helper/EndlessRecyclerViewScrollListener.java
@@ -1,0 +1,41 @@
+package com.ninchat.sdk.helper;
+
+import android.support.annotation.NonNull;
+import android.support.v7.widget.RecyclerView;
+
+import org.jetbrains.annotations.NotNull;
+
+public class EndlessRecyclerViewScrollListener extends RecyclerView.OnScrollListener {
+    private boolean updateData = false;
+    private int index;
+    private boolean updated;
+    private boolean removed;
+
+    @NonNull
+    private final Callback callback;
+
+    public EndlessRecyclerViewScrollListener(@NotNull Callback callback) {
+        this.callback = callback;
+    }
+
+    public void setData(final int index, final boolean updated, final boolean removed) {
+        updateData = true;
+        this.index = index;
+        this.updated = updated;
+        this.removed = removed;
+    }
+
+    @Override
+    public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
+        if (recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_IDLE && updateData) {
+            this.callback.requiredMessageUpdate(index, updated, removed);
+            updateData = false;
+        }
+        super.onScrollStateChanged(recyclerView, newState);
+    }
+
+    public interface Callback {
+        void requiredMessageUpdate(int index, boolean updated, boolean removed);
+    }
+
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/helper/NinchatAvatar.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/helper/NinchatAvatar.java
@@ -1,0 +1,68 @@
+package com.ninchat.sdk.helper;
+
+import android.content.Context;
+import android.support.annotation.VisibleForTesting;
+import android.text.TextUtils;
+import android.view.View;
+import android.widget.ImageView;
+
+import com.ninchat.sdk.GlideApp;
+import com.ninchat.sdk.NinchatSessionManager;
+import com.ninchat.sdk.models.NinchatMessage;
+import com.ninchat.sdk.models.NinchatUser;
+
+public class NinchatAvatar {
+    public void setAvatar(final Context mContext,
+                          final ImageView avatar,
+                          final NinchatMessage ninchatMessage,
+                          final boolean hideAvatar) {
+        final NinchatUser user = NinchatSessionManager.getInstance().getMember(ninchatMessage.getSenderId());
+        final String userAvatarText = getUserAvatarText(user, ninchatMessage.isRemoteMessage());
+        // set avatar
+        setAvatar(mContext, avatar, userAvatarText);
+        final boolean invisible = NinchatSessionManager.getInstance().showAvatars(ninchatMessage.isRemoteMessage());
+        if (!invisible) {
+            showAvatar(avatar);
+        } else if (hideAvatar) {
+            hideAvatar(avatar, invisible);
+        }
+    }
+
+    @VisibleForTesting
+    protected void setAvatar(final Context mContext, final ImageView avatar, final String avatarText) {
+        if (TextUtils.isEmpty(avatarText)) {
+            return;
+        }
+        GlideApp.with(mContext)
+                .load(avatarText)
+                .circleCrop()
+                .into(avatar);
+    }
+
+    @VisibleForTesting
+    protected String getUserAvatarText(final NinchatUser user, final boolean remoteMessage) {
+        String avatarText = user != null ? user.getAvatar() : null;
+
+        if (TextUtils.isEmpty(avatarText)) {
+            avatarText = NinchatSessionManager.getInstance().getDefaultAvatar(remoteMessage);
+        }
+
+        return avatarText;
+    }
+
+    @VisibleForTesting
+    protected void showAvatar(final ImageView avatar) {
+        if (avatar == null) {
+            return;
+        }
+        avatar.setVisibility(View.GONE);
+    }
+
+    @VisibleForTesting
+    protected void hideAvatar(final ImageView avatar, final boolean invisible) {
+        if (avatar == null) {
+            return;
+        }
+        avatar.setVisibility(invisible ? View.INVISIBLE : View.GONE);
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/helper/NinchatEndlessRecyclerViewScrollListener.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/helper/NinchatEndlessRecyclerViewScrollListener.java
@@ -5,7 +5,7 @@ import android.support.v7.widget.RecyclerView;
 
 import org.jetbrains.annotations.NotNull;
 
-public class EndlessRecyclerViewScrollListener extends RecyclerView.OnScrollListener {
+public class NinchatEndlessRecyclerViewScrollListener extends RecyclerView.OnScrollListener {
     private boolean updateData = false;
     private int index;
     private boolean updated;
@@ -14,7 +14,7 @@ public class EndlessRecyclerViewScrollListener extends RecyclerView.OnScrollList
     @NonNull
     private final Callback callback;
 
-    public EndlessRecyclerViewScrollListener(@NotNull Callback callback) {
+    public NinchatEndlessRecyclerViewScrollListener(@NotNull Callback callback) {
         this.callback = callback;
     }
 

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/helper/NinchatEndlessRecyclerViewScrollListener.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/helper/NinchatEndlessRecyclerViewScrollListener.java
@@ -5,37 +5,18 @@ import android.support.v7.widget.RecyclerView;
 
 import org.jetbrains.annotations.NotNull;
 
-public class NinchatEndlessRecyclerViewScrollListener extends RecyclerView.OnScrollListener {
-    private boolean updateData = false;
-    private int index;
-    private boolean updated;
-    private boolean removed;
+public abstract class NinchatEndlessRecyclerViewScrollListener extends RecyclerView.OnScrollListener {
 
-    @NonNull
-    private final Callback callback;
-
-    public NinchatEndlessRecyclerViewScrollListener(@NotNull Callback callback) {
-        this.callback = callback;
-    }
-
-    public void setData(final int index, final boolean updated, final boolean removed) {
-        updateData = true;
-        this.index = index;
-        this.updated = updated;
-        this.removed = removed;
-    }
+    public NinchatEndlessRecyclerViewScrollListener() { }
 
     @Override
     public void onScrollStateChanged(@NonNull RecyclerView recyclerView, int newState) {
-        if (recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_IDLE && updateData) {
-            this.callback.requiredMessageUpdate(index, updated, removed);
-            updateData = false;
+        if (recyclerView.getScrollState() == RecyclerView.SCROLL_STATE_IDLE) {
+            onUpdateView(recyclerView, newState);
         }
         super.onScrollStateChanged(recyclerView, newState);
     }
 
-    public interface Callback {
-        void requiredMessageUpdate(int index, boolean updated, boolean removed);
-    }
+    public abstract void onUpdateView(RecyclerView recyclerView, int newState);
 
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/models/NinchatMessageList.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/models/NinchatMessageList.java
@@ -1,0 +1,83 @@
+package com.ninchat.sdk.models;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+public class NinchatMessageList {
+    private List<String> ids;
+    private Map<String, NinchatMessage> idMap;
+
+    public NinchatMessageList() {
+        ids = new ArrayList<>();
+        idMap = new HashMap<>();
+    }
+
+    public int add(final String writingId, final NinchatMessage ninchatMessage) {
+        ids.add(writingId);
+        idMap.put(writingId, ninchatMessage);
+        Collections.sort(ids);
+        return ids.indexOf(writingId);
+    }
+
+    public void remove(final String writingPrefix, final String writingId) {
+        StringBuilder sb = new StringBuilder();
+        if (writingPrefix != null) {
+            sb.append(writingPrefix);
+        }
+        if (writingId != null) {
+            sb.append(writingId);
+        }
+        ids.remove(sb.toString());
+        Collections.sort(ids);
+    }
+
+    public boolean contains(final String writingId) {
+        return ids.contains(writingId);
+    }
+
+    public int getPosition(final String writingId) {
+        return ids.indexOf(writingId);
+    }
+
+    public long getItemId(final int position) {
+        return ids.get(position).hashCode();
+    }
+
+    public NinchatMessage getMessage(final int position) {
+        final String writingId = ids.get(position);
+        return idMap.get(writingId);
+    }
+
+    public String getLastMessageId(final boolean allowMeta) {
+        if (isEmpty()) {
+            return ""; // Imaginary message id preceding all actual ids.
+        }
+        final ListIterator<String> iterator = ids.listIterator(size() - 1);
+        while (iterator.hasPrevious() && !allowMeta) {
+            final String id = iterator.previous();
+            final NinchatMessage message = idMap.get(id);
+            if (message != null &&
+                    (message.getType() == NinchatMessage.Type.MESSAGE ||
+                            message.getType() == NinchatMessage.Type.MULTICHOICE)) {
+                return id;
+            }
+        }
+        return ids.get(size() - 1);
+    }
+
+    public int size() {
+        return ids.size();
+    }
+
+    public boolean isEmpty() {
+        return ids.isEmpty();
+    }
+
+    public void clear() {
+        ids.clear();
+    }
+}

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/models/NinchatMessageList.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/models/NinchatMessageList.java
@@ -1,6 +1,7 @@
 package com.ninchat.sdk.models;
 
 import java.util.ArrayList;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;

--- a/ninchatsdk/src/test/java/com/ninchat/sdk/adapters/NinchatQueueListAdapterTest.kt
+++ b/ninchatsdk/src/test/java/com/ninchat/sdk/adapters/NinchatQueueListAdapterTest.kt
@@ -1,0 +1,57 @@
+package com.ninchat.sdk.adapters
+
+import android.app.Activity
+import com.ninchat.sdk.models.NinchatQueue
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.*
+
+class NinchatQueueListAdapterTest {
+
+    @Test
+    fun `should initiate NinchatQueueListAdapter with activity and ninchat queue list`() {
+        val activity = mock(Activity::class.java)
+        val queue = mock(NinchatQueue::class.java)
+        NinchatQueueListAdapter(activity, mutableListOf(queue, queue, queue, queue, queue))
+    }
+
+    @Test
+    fun `should return 0 when queue is null`() {
+        val activity = mock(Activity::class.java)
+        val ninchatActivity = NinchatQueueListAdapter(activity, mutableListOf())
+        Assert.assertEquals(0, ninchatActivity.itemCount)
+    }
+
+    @Test
+    fun `should return 5 for queue size 5`() {
+        val activity = mock(Activity::class.java)
+        val queue = mock(NinchatQueue::class.java)
+        val ninchatActivity = NinchatQueueListAdapter(activity, mutableListOf(queue, queue, queue, queue, queue))
+        Assert.assertEquals(5, ninchatActivity.itemCount)
+    }
+
+    @Test
+    fun `should remove all element from queue and call notifyDataSetChanged`() {
+        val activity = mock(Activity::class.java)
+        val queue = mock(NinchatQueue::class.java)
+        val ninchatActivity = NinchatQueueListAdapter(activity, mutableListOf(queue, queue, queue, queue, queue))
+        val mockedNinchatActivity = spy(ninchatActivity)
+        doNothing().`when`(mockedNinchatActivity).notifyDataSetChanged()
+        mockedNinchatActivity.clearData()
+        Assert.assertEquals(0, mockedNinchatActivity.itemCount)
+    }
+
+    @Test
+    fun `should add a new queue item in queue list and call notifyItemRangeInserted`() {
+        val activity = mock(Activity::class.java)
+        val queue = mock(NinchatQueue::class.java)
+        val ninchatActivity = NinchatQueueListAdapter(activity, mutableListOf(queue, queue, queue, queue, queue))
+        val mockedNinchatActivity = spy(ninchatActivity)
+        doNothing().`when`(mockedNinchatActivity).notifyItemRangeInserted(ArgumentMatchers.anyInt(), ArgumentMatchers.anyInt())
+
+        val previousSize = ninchatActivity.itemCount
+        mockedNinchatActivity.addData(queue)
+        Assert.assertEquals(previousSize + 1, mockedNinchatActivity.itemCount)
+    }
+}

--- a/ninchatsdk/src/test/java/com/ninchat/sdk/adapters/holders/NinchatMultiChoiceViewholderTest.kt
+++ b/ninchatsdk/src/test/java/com/ninchat/sdk/adapters/holders/NinchatMultiChoiceViewholderTest.kt
@@ -1,0 +1,54 @@
+package com.ninchat.sdk.adapters.holders
+
+import android.view.View
+import android.widget.TextView
+import com.ninchat.sdk.models.NinchatMessage
+import com.ninchat.sdk.models.NinchatOption
+import org.json.JSONObject
+import org.junit.Assert
+import org.junit.Test
+import org.mockito.Mockito.*
+
+class NinchatMultiChoiceViewholderTest {
+    @Test
+    fun `should initiate NinchatMultiChoiceViewholder`() {
+        NinchatMultiChoiceViewholder(mock(View::class.java))
+    }
+
+    @Test
+    fun `should return ninchat option`() {
+        val ninchatOption = mutableListOf(mock(NinchatOption::class.java))
+        val ninchatMessage = NinchatMessage(
+                NinchatMessage.Type.META,
+                null,
+                null,
+                mock(JSONObject::class.java),
+                ninchatOption,
+                0L
+        )
+
+        val ninchatMultiChoiceViewholder = NinchatMultiChoiceViewholder(mock(View::class.java))
+        Assert.assertEquals(ninchatOption, ninchatMultiChoiceViewholder.getNinchatOptions(ninchatMessage))
+    }
+
+    @Test
+    fun `should return correct option for given index`() {
+        val ninchatOption = mutableListOf(mock(NinchatOption::class.java),
+                mock(NinchatOption::class.java),
+                mock(NinchatOption::class.java))
+
+        val ninchatMultiChoiceViewholder = NinchatMultiChoiceViewholder(mock(View::class.java))
+        Assert.assertEquals(ninchatOption[0], ninchatMultiChoiceViewholder.getNinchatOption(ninchatOption,0))
+        Assert.assertNotEquals(ninchatOption[0], ninchatMultiChoiceViewholder.getNinchatOption(ninchatOption,1))
+    }
+
+    @Test
+    fun `should call sendUIAction with selected option when sendAction is true`() {
+        // todo cover with instrumental test
+    }
+
+    @Test
+    fun `should call callback  with selected option when sendAction is true`() {
+        // todo cover with instrumental test
+    }
+}

--- a/ninchatsdk/src/test/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolderTest.kt
+++ b/ninchatsdk/src/test/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolderTest.kt
@@ -11,16 +11,17 @@ import org.mockito.ArgumentMatchers
 import org.mockito.Mockito.*
 
 class NinchatQueueViewHolderTest {
-    @Test
-    fun `should create a NinchatQueueViewHolder class`() {
-        val viewItem = mock(View::class.java)
-        NinchatQueueViewHolder(viewItem)
-    }
 
     lateinit var mItemView: View
     @Before
     fun setup() {
         mItemView = mock(View::class.java)
+    }
+
+    @Test
+    fun `should create a NinchatQueueViewHolder class`() {
+        val viewItem = mock(View::class.java)
+        NinchatQueueViewHolder(viewItem)
     }
 
     @Test

--- a/ninchatsdk/src/test/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolderTest.kt
+++ b/ninchatsdk/src/test/java/com/ninchat/sdk/adapters/holders/NinchatQueueViewHolderTest.kt
@@ -1,0 +1,64 @@
+package com.ninchat.sdk.adapters.holders
+
+import android.content.Context
+import android.view.View
+import android.widget.Button
+import com.ninchat.sdk.models.NinchatQueue
+import org.junit.Assert
+import org.junit.Before
+import org.junit.Test
+import org.mockito.ArgumentMatchers
+import org.mockito.Mockito.*
+
+class NinchatQueueViewHolderTest {
+    @Test
+    fun `should create a NinchatQueueViewHolder class`() {
+        val viewItem = mock(View::class.java)
+        NinchatQueueViewHolder(viewItem)
+    }
+
+    lateinit var mItemView: View
+    @Before
+    fun setup() {
+        mItemView = mock(View::class.java)
+    }
+
+    @Test
+    fun `getText should return null when queue is empty`() {
+        val mNinchatQueueViewHolder = NinchatQueueViewHolder(mItemView)
+        Assert.assertNull(mNinchatQueueViewHolder.getText(null))
+    }
+
+    @Test
+    fun `set button click listener, and setAlpha when queue is open`() {
+        val mQueue = mock(NinchatQueue::class.java)
+        `when`(mQueue.isClosed).thenReturn(false)
+
+        val mButton = mock(Button::class.java)
+        val viewHolder = NinchatQueueViewHolder(mItemView)
+        val mockedViewHolder = spy(viewHolder)
+        `when`(mockedViewHolder.getText(ArgumentMatchers.any())).thenReturn("")
+        `when`(mockedViewHolder.buttonItem).thenReturn(mButton)
+        mockedViewHolder.bind(mQueue, mock(NinchatQueueViewHolder.Callback::class.java))
+
+        verify(mButton).setOnClickListener(ArgumentMatchers.any())
+        verify(mButton).alpha = 1f
+    }
+
+
+    @Test
+    fun `should not set button click listener, and set button disabled with set alpha when queue is close`() {
+        val mQueue = mock(NinchatQueue::class.java)
+        `when`(mQueue.isClosed).thenReturn(true)
+
+        val mButton = mock(Button::class.java)
+        val viewHolder = NinchatQueueViewHolder(mItemView)
+        val mockedViewHolder = spy(viewHolder)
+        `when`(mockedViewHolder.getText(ArgumentMatchers.any())).thenReturn("")
+        `when`(mockedViewHolder.buttonItem).thenReturn(mButton)
+        mockedViewHolder.bind(mQueue, mock(NinchatQueueViewHolder.Callback::class.java))
+
+        verify(mButton).alpha = 0.5f
+        verify(mButton).isEnabled = false
+    }
+}


### PR DESCRIPTION
- Refactored ninchat message adapter and removed few costly of workarounds
- Separate views from ninchat message adapter, and delegate them to the corresponding viewholders ( require to simply them more )
- Add more unit tests
- Removed circular calls among activity, adapter and view holders ( more todos left. )
- Removed in scoped hack for handling `writing`, and `add message` type
- Removed application-specific logic from infinite scroll-listener class 

