### PR TITLE
305/SDK crashes in input field

### DIFF
--- a/ninchatsdk/src/main/res/layout/text_area_with_label.xml
+++ b/ninchatsdk/src/main/res/layout/text_area_with_label.xml
@@ -24,6 +24,8 @@
         android:gravity="top"
         android:inputType="textMultiLine|textCapSentences"
         android:minHeight="80dp"
+        android:selectAllOnFocus="false"
+        android:imeOptions="actionDone"
         android:maxLines="4"
         tools:hint="Enter text" />
 

--- a/ninchatsdk/src/main/res/layout/text_field_with_label.xml
+++ b/ninchatsdk/src/main/res/layout/text_field_with_label.xml
@@ -24,6 +24,7 @@
         android:inputType="text|textCapSentences"
         android:minHeight="50dp"
         android:selectAllOnFocus="false"
+        android:imeOptions="actionDone"
         android:singleLine="true"
         tools:hint="Enter text" />
 


### PR DESCRIPTION
Fix SDK crash 
 - `java.lang.IllegalStateException: focus search returned a view that wasn't able to take focus!`

More details
https://github.com/somia/mobile/issues/305