### PR TITLE
Add missing textColor for command element ( Chat input text )

### DIFF
--- a/ninchatsdk/src/main/res/layout/activity_ninchat_chat.xml
+++ b/ninchatsdk/src/main/res/layout/activity_ninchat_chat.xml
@@ -35,6 +35,7 @@
             tools:hint="Enter your message"
             android:layout_margin="@dimen/ninchat_chat_activity_message_margin"
             android:textColorHint="@color/ninchat_color_textarea_text"
+            android:textColor="@color/ninchat_color_textarea_text"
             android:background="@null"
             android:inputType="textMultiLine|textCapSentences"
             android:maxLines="6"


### PR DESCRIPTION
Add missing textColor for chat input text. 
 - Previously it was only used for hint