### PR TITLE
titlebar: "conversation" as the default fallback

### DIFF
--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchattitlebar/view/NinchatTitlebarView.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchattitlebar/view/NinchatTitlebarView.kt
@@ -79,7 +79,7 @@ class NinchatTitlebarView {
             val titleBarInfo = when (displayInfo) {
                 "questionnaire" -> getTitleBarInfoFromAudienceQuestionnaire()
                 "agent" -> getTitleBarInfoFromAgent()
-                else -> null
+                else -> getTitleBarInfoFromAudienceQuestionnaire()
             } ?: return
             //1: if no questionnaire name
             //2: if no questionnaire name and no questionnaire avatar


### PR DESCRIPTION
 For post audience questionnaire if no information is given for"postAudienceQuestionnaireTitlebar"; it will fallback to same as "questionnaire" style as default