### PR TITLE
Bugfix: pre-audience questionnaire message

### DIFF
--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnaireactivity/presenter/NinchatQuestionnairePresenter.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnaireactivity/presenter/NinchatQuestionnairePresenter.kt
@@ -176,11 +176,6 @@ class NinchatQuestionnairePresenter(
     fun isPostAudienceQuestionnaire(): Boolean =
         model.questionnaireType == NinchatQuestionnaireConstants.postAudienceQuestionnaire
 
-    fun savePreAudienceQuestionnaireMessage() {
-        val answer = model.answers?.answerList?.findLast { it -> it.first == "message" }
-        NinchatSessionManager.getInstance()?.ninchatState?.message = answer?.second ?: ""
-    }
-
     companion object {
         val REQUEST_CODE = NinchatQuestionnairePresenter::class.java.hashCode() and 0xffff
         fun getLaunchIntent(context: Context?, queueId: String?, questionnaireType: Int): Intent {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnaireactivity/view/NinchatQuestionnaireActivity.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnaireactivity/view/NinchatQuestionnaireActivity.kt
@@ -181,7 +181,6 @@ class NinchatQuestionnaireActivity : NinchatBaseActivity(), INinchatQuestionnair
             putExtra(NinchatQuestionnaireModel.QUEUE_ID, presenter.queueId())
             putExtra(NinchatQuestionnaireModel.OPEN_QUEUE, openQueue)
         }
-        presenter.savePreAudienceQuestionnaireMessage()
         setResult(RESULT_OK, intent)
         finish()
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/states/NinchatState.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/states/NinchatState.kt
@@ -103,8 +103,6 @@ class NinchatState {
 
     var skippedReview = false
 
-    var message = ""
-
     fun dispose() {
         userId = null
         channelId = null
@@ -127,6 +125,5 @@ class NinchatState {
         members.clear()
         queues.clear()
         skippedReview = false
-        message = ""
     }
 }


### PR DESCRIPTION
Instead of saving "message" from pre-answers in memory; now we get "message" from channel_attribute/pre ans when the audience is pick from the queue