### PR TITLE
Bugfix/media-toggle

### DIFF
--- a/ninchatsdk/src/main/java/com/ninchat/sdk/views/NinchatWebRTCView.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/views/NinchatWebRTCView.java
@@ -382,8 +382,13 @@ public final class NinchatWebRTCView implements PeerConnection.Observer, SdpObse
 
     @Override
     public void onConnectionChange(PeerConnection.PeerConnectionState newState) {
-        if (newState == PeerConnection.PeerConnectionState.FAILED) {
+        if (newState == PeerConnection.PeerConnectionState.FAILED || newState == PeerConnection.PeerConnectionState.CLOSED) {
             new Handler(Looper.getMainLooper()).post(() -> hangUp(true));
+        } else if (newState == PeerConnection.PeerConnectionState.CONNECTED) {
+            new Handler(Looper.getMainLooper()).post(() -> {
+                // show controls button
+                videoContainer.findViewById(R.id.video_call_media_controls).setVisibility(View.VISIBLE);
+            });
         }
     }
 
@@ -661,6 +666,7 @@ public final class NinchatWebRTCView implements PeerConnection.Observer, SdpObse
         microphoneImage.setImageResource(R.drawable.ninchat_icon_video_microphone_on);
         audioImage.setImageResource(R.drawable.ninchat_icon_video_sound_on);
         videoImage.setImageResource(R.drawable.ninchat_icon_video_camera_on);
+        videoContainer.findViewById(R.id.video_call_media_controls).setVisibility(View.GONE);
     }
 
     public void onResume() {

--- a/ninchatsdk/src/main/res/layout/activity_ninchat_chat.xml
+++ b/ninchatsdk/src/main/res/layout/activity_ninchat_chat.xml
@@ -151,11 +151,14 @@
             tools:visibility="visible" />
 
         <LinearLayout
+            android:id="@+id/video_call_media_controls"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"
             android:layout_alignParentStart="true"
             android:layout_alignParentBottom="true"
             android:orientation="horizontal"
+            android:visibility="gone"
+            tools:visibility="visible"
             android:padding="@dimen/ninchat_chat_activity_video_control_padding">
 
             <ImageView


### PR DESCRIPTION
Fix a corner case, where if you try to toggle video or audio before the webrtc internal initialise; it can lead to a crash. One of the possible fix is to allow user to toggle audio and video only after webrtc connection is actually up