### PR TITLE
sdk/autolink: custom autolink behaviour

### DIFF
--- a/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/adapters/NinchatMessageAdapter.java
@@ -130,15 +130,18 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
             playIcon.setVisibility(View.GONE);
             GlideApp.with(image.getContext()).clear(image);
             image.setBackground(null);
+            final String autoLinkAttributes = itemView.getResources().getString(R.string.ninchat_autolink_attributes);
+            final Integer autoLinkMask = Misc.autoLinkMask(autoLinkAttributes);
             if (messageContent != null) {
                 message.setVisibility(View.VISIBLE);
-                message.setAutoLinkMask(Linkify.ALL);
+                message.setAutoLinkMask(autoLinkMask);
                 message.setText(messageContent);
                 if (isDeletedMessage)
                     message.setTypeface(null, Typeface.ITALIC);
             } else if (file.isDownloadableFile()) {
                 message.setVisibility(View.VISIBLE);
                 message.setText(file.getFileLink());
+
                 message.setMovementMethod(LinkMovementMethod.getInstance());
             } else {
                 final int width = file.getWidth();
@@ -161,7 +164,7 @@ public final class NinchatMessageAdapter extends RecyclerView.Adapter<NinchatMes
             if (isContinuedMessage) {
                 itemView.findViewById(wrapperId).setPadding(0, 0, 0, 0);
             } else {
-                if(!isDeletedMessage)
+                if (!isDeletedMessage)
                     itemView.findViewById(headerId).setVisibility(View.VISIBLE);
             }
         }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/utils/misc/Misc.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/utils/misc/Misc.kt
@@ -12,6 +12,7 @@ import android.provider.OpenableColumns
 import android.text.Html
 import android.text.Spanned
 import android.text.method.LinkMovementMethod
+import android.text.util.Linkify
 import android.util.Log
 import android.webkit.MimeTypeMap
 import android.widget.TextView
@@ -97,6 +98,25 @@ class Misc {
             return state?.let {
                 it.skippedReview || !it.hasQuestionnaire(false)
             } ?: false
+        }
+
+        // WEB_URLS, EMAIL_ADDRESSES, PHONE_NUMBERS, MAP_ADDRESSES, ALL
+        @JvmStatic
+        fun autoLinkMask(stringValue: String): Int {
+            if ("none" == stringValue) return 0
+            val linkMaskMap = mapOf(
+                "web" to Linkify.WEB_URLS,
+                "email" to Linkify.EMAIL_ADDRESSES,
+                "phone" to Linkify.PHONE_NUMBERS,
+                "map" to Linkify.MAP_ADDRESSES,
+                "all" to Linkify.ALL,
+            )
+            return stringValue
+                .split('|')
+                .mapNotNull(linkMaskMap::get)
+                .reduceOrNull { acc, current ->
+                    acc or current
+                } ?: Linkify.ALL // default is all
         }
     }
 }

--- a/ninchatsdk/src/main/res/values/strings.xml
+++ b/ninchatsdk/src/main/res/values/strings.xml
@@ -36,4 +36,6 @@
     <string name="ninchat_audience_queue">dummy_value</string>
     <string name="ninchat_audience_queue_wrong">dummy_value</string>
 
+    <string name="ninchat_autolink_attributes">all</string>
+
 </resources>


### PR DESCRIPTION
SDK now expose a resource string `ninchat_autolink_attributes`, that can be used to control autolink behaviour in chat messages view

Auto link for questionnaire items behave differently ( handle by questionnaire type `hyperlink element` ) and left as it is.