### PR TITLE
Activity dispose callback

### DIFF
--- a/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSDKEventListener.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSDKEventListener.java
@@ -11,4 +11,5 @@ public abstract class NinchatSDKEventListener {
     public void onSessionEvent(final Props params) {}
     public void onEvent(final Props params, final Payload payload) {}
     public void onSessionError(final Exception error) {}
+    public void onActivityDropped() {}
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSessionManager.java
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/NinchatSessionManager.java
@@ -313,6 +313,10 @@ public final class NinchatSessionManager {
     }
 
     public void close() {
+        if(ninchatState != null) {
+            ninchatState.setPendingSessionState(Misc.SESSION_CLOSING);
+        }
+
         if (ninchatSessionHolder != null) {
             ninchatSessionHolder.dispose();
         }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/helper/session/NinchatSessionHolder.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/helper/session/NinchatSessionHolder.kt
@@ -72,8 +72,18 @@ class NinchatSessionHolder(ninchatState: NinchatState) {
         listener: NinchatSDKEventListener?
     ) {
         currentSession = session
-        session.setOnClose { Log.v(TAG, "onClose") }
-        session.setOnConnState { state -> Log.v(TAG, "onConnState: $state") }
+        session.setOnClose {
+            ninchatState.pendingSessionState = Misc.SESSION_CLOSED;
+            Log.v(TAG, "onClose")
+        }
+        session.setOnConnState { state ->
+            Log.v(TAG, "onConnState: $state")
+            ninchatState.pendingSessionState = when (state) {
+                "connected", "connecting" -> Misc.SESSION_OPENED
+                "disconnected" -> Misc.SESSION_CLOSED
+                else -> ninchatState.pendingSessionState
+            }
+        }
         session.setOnLog { msg -> Log.v(TAG, "onLog: $msg") }
 
         session.setOnSessionEvent { params: Props ->

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatactivity/presenter/NinchatActivityPresenter.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatactivity/presenter/NinchatActivityPresenter.kt
@@ -18,6 +18,7 @@ import com.ninchat.sdk.ninchatquestionnaire.helper.NinchatQuestionnaireConstants
 import com.ninchat.sdk.ninchatquestionnaire.ninchatquestionnaireactivity.presenter.NinchatQuestionnairePresenter
 import com.ninchat.sdk.ninchatqueue.model.NinchatQueueModel
 import com.ninchat.sdk.ninchatqueue.presenter.NinchatQueuePresenter
+import com.ninchat.sdk.utils.misc.Misc
 import com.ninchat.sdk.utils.misc.Misc.Companion.toRichText
 
 
@@ -107,6 +108,15 @@ class NinchatActivityPresenter(
         }
     }
 
+
+    fun maybeDisposeSession() {
+        NinchatSessionManager.getInstance()?.let { ninchatSessionManager ->
+            if(ninchatSessionManager.ninchatState?.pendingSessionState == Misc.SESSION_OPENED) {
+                ninchatSessionManager.eventListenerWeakReference?.get()?.onActivityDropped();
+            }
+            ninchatSessionManager.close()
+        }
+    }
 
     var queuesUpdatedReceiver: BroadcastReceiver = object : BroadcastReceiver() {
         override fun onReceive(context: Context, intent: Intent) {

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatactivity/view/NinchatActivity.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatactivity/view/NinchatActivity.kt
@@ -13,6 +13,7 @@ import com.ninchat.sdk.ninchatactivity.presenter.NinchatActivityPresenter
 import com.ninchat.sdk.ninchatquestionnaire.ninchatquestionnaireactivity.model.NinchatQuestionnaireModel
 import com.ninchat.sdk.ninchatquestionnaire.ninchatquestionnaireactivity.presenter.NinchatQuestionnairePresenter
 import com.ninchat.sdk.ninchatqueue.model.NinchatQueueModel
+import com.ninchat.sdk.utils.misc.Misc
 import kotlinx.android.synthetic.main.activity_ninchat.*
 
 class NinchatActivity : NinchatBaseActivity(), INinchatActivityPresenter {
@@ -72,11 +73,15 @@ class NinchatActivity : NinchatBaseActivity(), INinchatActivityPresenter {
     }
 
     override fun onDestroy() {
+        ninchatActivityPresenter.maybeDisposeSession()
         ninchatActivityPresenter.unSubscribeBroadcaster()
         super.onDestroy()
     }
 
     fun onCloseClick(view: View?) {
+        NinchatSessionManager.getInstance()?.ninchatState?.let { state ->
+            state.pendingSessionState = Misc.SESSION_CLOSING
+        }
         setResult(RESULT_CANCELED)
         finish()
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/states/NinchatState.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/states/NinchatState.kt
@@ -21,6 +21,7 @@ class NinchatState {
     var requestCode: Int = 0
     var queueId: String? = null
     var currentSessionState: Int = Misc.NEW_SESSION
+    var pendingSessionState = Misc.SESSION_CLOSED;
 
     var userChannels: Props? = null
     var userQueues: Props? = null
@@ -112,6 +113,7 @@ class NinchatState {
         isGroupVideoChannel = false
         queueId = null
         currentSessionState = Misc.NEW_SESSION
+        pendingSessionState = Misc.SESSION_CLOSED
         userChannels = null
         userQueues = null
         audienceMetadata?.remove()

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/utils/misc/Misc.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/utils/misc/Misc.kt
@@ -29,7 +29,10 @@ class Misc {
         const val NEW_SESSION = 0
         const val IN_QUEUE = 2
         const val HAS_CHANNEL = 3
-        const val NONE = 4
+        const val SESSION_CLOSING = 4
+        const val SESSION_CLOSED = 5
+        const val SESSION_OPENED = 6
+        const val NONE = 7
 
         @JvmStatic
         fun center(text: String?): String {


### PR DESCRIPTION
`onActivityDropped` is introduced when system decides to dispose the activity due to system or memory constraints, or when the application is resumed from the background by clicking the app icon from the application list.

`pendingSessionState` is introduced to session handling more clearly 