### PR TITLE
Bugfix: scrolling in form-like-questionnaire

### DIFF
--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnairelist/presenter/NinchatFormListPresenter.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnairelist/presenter/NinchatFormListPresenter.kt
@@ -105,4 +105,8 @@ class NinchatFormListPresenter(
     override fun getByMuskedPosition(index: Int): JSONObject = model.answerList.takeLast(model.selectedElement.lastOrNull()?.second
             ?: 0).getOrNull(index) ?: JSONObject()
 
+    override fun getUnmaskedPosition(position: Int): Int {
+        return ((position + (model.selectedElement.lastOrNull()?.second ?: 1)) % model.answerList.size)
+    }
+
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnairelist/presenter/NinchatQuestionnaireListPresenter.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnairelist/presenter/NinchatQuestionnaireListPresenter.kt
@@ -168,4 +168,8 @@ open class NinchatQuestionnaireListPresenter(
     open fun getByMuskedPosition(index: Int): JSONObject {
         TODO("implement me")
     }
+
+    open fun getUnmaskedPosition(position: Int): Int {
+        return position
+    }
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnairelist/view/NinchatQuestionnaireListAdapter.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatquestionnaire/ninchatquestionnairelist/view/NinchatQuestionnaireListAdapter.kt
@@ -265,5 +265,8 @@ class NinchatQuestionnaireListAdapter(
         presenter.showNext(onNextQuestionnaire)
     }
 
-    fun isLastElement(position: Int): Boolean = position + 2 >= presenter.size()
+    fun isLastElement(position: Int): Boolean {
+        val positionInView = presenter.getUnmaskedPosition(position)
+        return positionInView + 2 >= presenter.size()
+    }
 }


### PR DESCRIPTION
Questionnaire answers are stored in a flat list.

 - for conversation; the questionnaires come and processed as flat list. so finding the positions is straightforward there.
 - for form like questionnaire; the answers are process as flat list but questionnaires itself comes as bucket ( a group of questionnaire for each current view ). 

In form like questionnaire this consideration were ignore and thus we introduced a bug where the focused item were wrongly identified as **always** last  . 