### PR TITLE
Bugfix: softkeyboard handler crash

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,6 +7,7 @@ buildscript {
         google()
         jcenter()
         mavenCentral()
+        maven { url "https://plugins.gradle.org/m2/" }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.2.2'
@@ -27,6 +28,9 @@ allprojects {
         }
         maven {
             url "https://maven.google.com"
+        }
+        maven {
+            url "https://jitpack.io"
         }
     }
 }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatchatactivity/view/NinchatChatActivity.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatchatactivity/view/NinchatChatActivity.kt
@@ -102,7 +102,7 @@ class NinchatChatActivity : NinchatBaseActivity(), IOrientationManager {
         },
     )
 
-    lateinit var orientationManager: OrientationManager
+    var orientationManager: OrientationManager? = null
 
     override fun onOrientationChange(orientation: Int) {
         // if user manually toggle to full screen then don't change orientation
@@ -432,7 +432,7 @@ class NinchatChatActivity : NinchatBaseActivity(), IOrientationManager {
         mBroadcastManager.unregister(localBroadcastManager)
         softKeyboardViewHandler.unregister()
         presenter.writingIndicator.dispose()
-        orientationManager.disable()
+        orientationManager?.disable()
         EventBus.getDefault().unregister(this)
         super.onDestroy()
     }

--- a/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatchatactivity/view/SoftKeyboardViewHandler.kt
+++ b/ninchatsdk/src/main/java/com/ninchat/sdk/ninchatchatactivity/view/SoftKeyboardViewHandler.kt
@@ -2,13 +2,14 @@ package com.ninchat.sdk.ninchatchatactivity.view
 
 import android.content.res.Configuration
 import android.view.View
+import android.view.ViewTreeObserver
 
 class SoftKeyboardViewHandler(
     private val onHidden: () -> Unit,
     private val onShow: () -> Unit,
 ) {
     private var previousHeight = -1
-    private lateinit var rootView: View
+    private var rootView: View? = null
     private var wasOpen = false
 
     fun register(rootView: View) {
@@ -17,13 +18,14 @@ class SoftKeyboardViewHandler(
     }
 
     fun unregister() {
-        rootView.viewTreeObserver.removeOnGlobalLayoutListener(observer)
+        rootView?.viewTreeObserver?.removeOnGlobalLayoutListener(observer)
     }
 
-    private val observer = {
-        val height = rootView.height
+    private val observer = ViewTreeObserver.OnGlobalLayoutListener {
+        val currentRootView = rootView ?: return@OnGlobalLayoutListener
+        val height = currentRootView.height
         val heightDifference = height - previousHeight
-        val currentOrientation = rootView.resources.configuration.orientation
+        val currentOrientation = currentRootView.resources.configuration.orientation
         if (heightDifference > 0 && currentOrientation == Configuration.ORIENTATION_PORTRAIT) {
             // soft keyboard is hidden
             if (wasOpen) {


### PR DESCRIPTION
This change replaces lateinit with a null check to mitigate the crash. Previously, we assumed the crash path would never occur, but it seems there are scenario(s) that leading to the crash.